### PR TITLE
added animation handler to track animations on players and mobs

### DIFF
--- a/Maple2.File.Ingest/Mapper/AnimationMapper.cs
+++ b/Maple2.File.Ingest/Mapper/AnimationMapper.cs
@@ -18,7 +18,11 @@ public class AnimationMapper : TypeMapper<AnimationMetadata> {
                 IEnumerable<(string Name, AnimationSequence Sequence)> sequences = kfm.seq.Select(sequence => {
                     List<AnimationKey> keys = sequence.key.Select(key => new AnimationKey(key.name, (float) key.time)).ToList();
                     return (sequence.name,
-                        new AnimationSequence(Id: (short) sequence.id, Time: (float) (sequence.key.FirstOrDefault(key => key.name == "end")?.time ?? default), keys));
+                        new AnimationSequence(
+                            Name: sequence.name,
+                            Id: (short) sequence.id,
+                            Time: (float) (sequence.key.FirstOrDefault(key => key.name == "end")?.time ?? default), keys)
+                        );
                 });
 
                 var lookup = new Dictionary<string, AnimationSequence>();

--- a/Maple2.File.Ingest/Mapper/SkillMapper.cs
+++ b/Maple2.File.Ingest/Mapper/SkillMapper.cs
@@ -35,6 +35,10 @@ public class SkillMapper : TypeMapper<StoredSkillMetadata> {
                         SpRate: level.recoveryProperty.spRate),
                     Skills: level.conditionSkill.Select(skill => skill.Convert()).ToArray(),
                     Motions: level.motion.Select(motion => new SkillMetadataMotion(
+                        new SkillMetadataMotionProperty(
+                            SequenceName: motion.motionProperty.sequenceName,
+                            SequenceSpeed: motion.motionProperty.sequenceSpeed
+                        ),
                         Attacks: motion.attack.Select(attack => new SkillMetadataAttack(
                             Point: attack.point,
                             PointGroup: attack.pointGroupID,

--- a/Maple2.Model/Metadata/AnimationMetadata.cs
+++ b/Maple2.Model/Metadata/AnimationMetadata.cs
@@ -4,6 +4,6 @@ namespace Maple2.Model.Metadata;
 
 public record AnimationMetadata(string Model, IReadOnlyDictionary<string, AnimationSequence> Sequences);
 
-public record AnimationSequence(short Id, float Time, List<AnimationKey>? Keys);
+public record AnimationSequence(string Name, short Id, float Time, List<AnimationKey>? Keys);
 
 public record AnimationKey(string Name, float Time);

--- a/Maple2.Model/Metadata/Constants.cs
+++ b/Maple2.Model/Metadata/Constants.cs
@@ -84,6 +84,7 @@ public static class Constant {
     public const int PartyMinCapacity = 4;
     public const int GroupChatMaxCapacity = 20;
     public const int GroupChatMaxCount = 3;
+    public const long ClientGraceTimeTick = 500; // max time to allow client to go past loop & sequence end
 
 
     public const long FurnishingBaseId = 2870000000000000000;

--- a/Maple2.Model/Metadata/SkillMetadata.cs
+++ b/Maple2.Model/Metadata/SkillMetadata.cs
@@ -69,7 +69,12 @@ public record SkillMetadataRecovery(
     float SpRate);
 
 public record SkillMetadataMotion(
+    SkillMetadataMotionProperty MotionProperty,
     SkillMetadataAttack[] Attacks);
+
+public record SkillMetadataMotionProperty(
+    string SequenceName,
+    float SequenceSpeed);
 
 public record SkillMetadataAttack(
     string Point,

--- a/Maple2.Server.Game/Commands/DebugCommand.cs
+++ b/Maple2.Server.Game/Commands/DebugCommand.cs
@@ -1,0 +1,93 @@
+﻿using Maple2.Server.Game.Session;
+using System.CommandLine.Invocation;
+using System.CommandLine;
+using Maple2.Database.Storage;
+using System.CommandLine.IO;
+
+namespace Maple2.Server.Game.Commands;
+
+public class DebugCommand : Command {
+    private const string NAME = "debug";
+    private const string DESCRIPTION = "Debug information management.";
+
+    private readonly NpcMetadataStorage npcStorage;
+
+    public DebugCommand(GameSession session, NpcMetadataStorage npcStorage) : base(NAME, DESCRIPTION) {
+        this.npcStorage = npcStorage;
+
+        AddCommand(new DebugNpcAiCommand(session, npcStorage));
+        AddCommand(new DebugAnimationCommand(session));
+        AddCommand(new DebugSkillsCommand(session));
+    }
+
+    public class DebugNpcAiCommand : Command {
+        private readonly GameSession session;
+        private readonly NpcMetadataStorage npcStorage;
+
+        public DebugNpcAiCommand(GameSession session, NpcMetadataStorage npcStorage) : base("ai", "Toggles displaying npc AI debug info.") {
+            this.session = session;
+            this.npcStorage = npcStorage;
+
+            var enable = new Argument<bool?>("enable", () => true, "Enables & disables debug messages. Prints all AI state if true.");
+
+            AddArgument(enable);
+
+            this.SetHandler<InvocationContext, bool?>(Handle, enable);
+        }
+
+        private void Handle(InvocationContext ctx, bool? enabled) {
+            if (session.Field == null) {
+                ctx.Console.Error.WriteLine("No field loaded.");
+                return;
+            }
+
+            session.Player.DebugAi = enabled ?? true;
+
+            string message = enabled ?? true ? "Enabled" : "Disabled";
+            ctx.Console.Out.WriteLine($"{message} AI debug info printing");
+        }
+    }
+
+
+    private class DebugAnimationCommand : Command {
+        private readonly GameSession session;
+
+        public DebugAnimationCommand(GameSession session) : base("anims", "Prints player animation info.") {
+            this.session = session;
+
+            var enable = new Argument<bool?>("enable", () => true, "Enables & disables debug messages. Prints all animation state if true.");
+
+            AddArgument(enable);
+
+            this.SetHandler<InvocationContext, bool?>(Handle, enable);
+        }
+
+        private void Handle(InvocationContext ctx, bool? enabled) {
+            session.Player.AnimationState.DebugPrintAnimations = enabled ?? true;
+
+            string message = enabled ?? true ? "Enabled" : "Disabled";
+            ctx.Console.Out.WriteLine($"{message} animation debug info printing");
+        }
+    }
+
+    private class DebugSkillsCommand : Command {
+        private readonly GameSession session;
+
+        public DebugSkillsCommand(GameSession session) : base("skills", "Prints player skill packet info.") {
+            this.session = session;
+
+            var enable = new Argument<bool?>("enable", () => true, "Enables & disables debug messages. Prints all skill cast packets if true.");
+
+            AddArgument(enable);
+
+            this.SetHandler<InvocationContext, bool?>(Handle, enable);
+        }
+
+        private void Handle(InvocationContext ctx, bool? enabled) {
+            session.Player.DebugSkills = enabled ?? true;
+
+            string message = enabled ?? true ? "Enabled" : "Disabled";
+            ctx.Console.Out.WriteLine($"{message} skill cast packet debug info printing");
+        }
+    }
+}

--- a/Maple2.Server.Game/Commands/NpcCommand.cs
+++ b/Maple2.Server.Game/Commands/NpcCommand.cs
@@ -116,34 +116,3 @@ public class AnimateNpcCommand : Command {
         fieldNpc.Animate(animationKey);
     }
 }
-
-public class DebugNpcAiCommand : Command {
-    private const string NAME = "debugnpcs";
-    private const string DESCRIPTION = "Toggles displaying npc AI debug info.";
-
-    private readonly GameSession session;
-    private readonly NpcMetadataStorage npcStorage;
-
-    public DebugNpcAiCommand(GameSession session, NpcMetadataStorage npcStorage) : base(NAME, DESCRIPTION) {
-        this.session = session;
-        this.npcStorage = npcStorage;
-
-        var enable = new Argument<bool?>("enable", () => true, "Enables & disables debug messages. Prints all AI state if true.");
-
-        AddArgument(enable);
-
-        this.SetHandler<InvocationContext, bool?>(Handle, enable);
-    }
-
-    private void Handle(InvocationContext ctx, bool? enabled) {
-        if (session.Field == null) {
-            ctx.Console.Error.WriteLine("No field loaded.");
-            return;
-        }
-
-        session.Player.DebugAi = enabled ?? true;
-
-        string message = enabled ?? true ? "Enabled" : "Disabled";
-        ctx.Console.Out.WriteLine($"{message} AI debug info printing");
-    }
-}

--- a/Maple2.Server.Game/Commands/PlayerCommand.cs
+++ b/Maple2.Server.Game/Commands/PlayerCommand.cs
@@ -19,6 +19,8 @@ public class PlayerCommand : Command {
         AddCommand(new ExpCommand(session));
         AddCommand(new JobCommand(session));
         AddCommand(new InfoCommand(session));
+        AddCommand(new DebugAnimationCommand(session));
+        AddCommand(new DebugSkillsCommand(session));
     }
 
     private class LevelCommand : Command {
@@ -162,6 +164,48 @@ public class PlayerCommand : Command {
             ctx.Console.Out.WriteLine($"Player: {session.Player.ObjectId} ({session.PlayerName})");
             ctx.Console.Out.WriteLine($"  Position: {session.Player.Position}");
             ctx.Console.Out.WriteLine($"  Rotation: {session.Player.Rotation}");
+        }
+    }
+
+    private class DebugAnimationCommand : Command {
+        private readonly GameSession session;
+
+        public DebugAnimationCommand(GameSession session) : base("debuganims", "Prints player animation info.") {
+            this.session = session;
+
+            var enable = new Argument<bool?>("enable", () => true, "Enables & disables debug messages. Prints all animation state if true.");
+
+            AddArgument(enable);
+
+            this.SetHandler<InvocationContext, bool?>(Handle, enable);
+        }
+
+        private void Handle(InvocationContext ctx, bool? enabled) {
+            session.Player.AnimationState.DebugPrintAnimations = enabled ?? true;
+
+            string message = enabled ?? true ? "Enabled" : "Disabled";
+            ctx.Console.Out.WriteLine($"{message} animation debug info printing");
+        }
+    }
+
+    private class DebugSkillsCommand : Command {
+        private readonly GameSession session;
+
+        public DebugSkillsCommand(GameSession session) : base("debugskills", "Prints player skill packet info.") {
+            this.session = session;
+
+            var enable = new Argument<bool?>("enable", () => true, "Enables & disables debug messages. Prints all skill cast packets if true.");
+
+            AddArgument(enable);
+
+            this.SetHandler<InvocationContext, bool?>(Handle, enable);
+        }
+
+        private void Handle(InvocationContext ctx, bool? enabled) {
+            session.Player.DebugSkills = enabled ?? true;
+
+            string message = enabled ?? true ? "Enabled" : "Disabled";
+            ctx.Console.Out.WriteLine($"{message} skill cast packet debug info printing");
         }
     }
 }

--- a/Maple2.Server.Game/Commands/PlayerCommand.cs
+++ b/Maple2.Server.Game/Commands/PlayerCommand.cs
@@ -19,8 +19,6 @@ public class PlayerCommand : Command {
         AddCommand(new ExpCommand(session));
         AddCommand(new JobCommand(session));
         AddCommand(new InfoCommand(session));
-        AddCommand(new DebugAnimationCommand(session));
-        AddCommand(new DebugSkillsCommand(session));
     }
 
     private class LevelCommand : Command {

--- a/Maple2.Server.Game/Manager/Field/FieldManager.Factory.cs
+++ b/Maple2.Server.Game/Manager/Field/FieldManager.Factory.cs
@@ -15,6 +15,7 @@ public partial class FieldManager {
         public required MapMetadataStorage MapMetadata { private get; init; }
         public required MapEntityStorage MapEntities { private get; init; }
         public required ServerTableMetadataStorage ServerTableMetadata { private get; init; }
+        public required NpcMetadataStorage NpcMetadata { get; init; } = null!;
         // ReSharper restore All
         #endregion
 
@@ -85,7 +86,7 @@ public partial class FieldManager {
             if (entities == null) {
                 throw new InvalidOperationException($"Failed to load entities for map: {mapId}");
             }
-            var field = new FieldManager(metadata, ugcMetadata, entities, ownerId);
+            var field = new FieldManager(metadata, ugcMetadata, entities, NpcMetadata, ownerId);
             context.InjectProperties(field);
             field.Init();
 

--- a/Maple2.Server.Game/Manager/Field/FieldManager.State.cs
+++ b/Maple2.Server.Game/Manager/Field/FieldManager.State.cs
@@ -48,7 +48,7 @@ public partial class FieldManager {
         player.Character.InstanceMapId = MapId;
         player.Character.InstanceId = InstanceId;
 
-        var fieldPlayer = new FieldPlayer(session, player) {
+        var fieldPlayer = new FieldPlayer(session, player, NpcMetadata) {
             Position = position,
             Rotation = rotation,
         };

--- a/Maple2.Server.Game/Manager/Field/FieldManager.cs
+++ b/Maple2.Server.Game/Manager/Field/FieldManager.cs
@@ -64,14 +64,14 @@ public sealed partial class FieldManager : IDisposable {
     public readonly int InstanceId;
     public readonly AiManager Ai;
 
-    public FieldManager(MapMetadata metadata, UgcMapMetadata ugcMetadata, MapEntityMetadata entities, long ownerId = 0) {
+    public FieldManager(MapMetadata metadata, UgcMapMetadata ugcMetadata, MapEntityMetadata entities, NpcMetadataStorage npcMetadata, long ownerId = 0) {
         Metadata = metadata;
         this.ugcMetadata = ugcMetadata;
         this.Entities = entities;
         TriggerObjects = new TriggerCollection(entities);
 
         Scheduler = new EventQueue();
-        FieldActor = new FieldActor(this);
+        FieldActor = new FieldActor(this, npcMetadata); // pulls from argument because member NpcMetadata is null here
         cancel = new CancellationTokenSource();
         thread = new Thread(Update);
         Ai = new AiManager(this);

--- a/Maple2.Server.Game/Model/Enum/AnimationType.cs
+++ b/Maple2.Server.Game/Model/Enum/AnimationType.cs
@@ -1,0 +1,7 @@
+﻿namespace Maple2.Server.Game.Model.Enum;
+
+public enum AnimationType {
+    Misc,
+    Move,
+    Skill
+}

--- a/Maple2.Server.Game/Model/Field/Actor/ActorState/AnimationState.cs
+++ b/Maple2.Server.Game/Model/Field/Actor/ActorState/AnimationState.cs
@@ -5,8 +5,6 @@ using Maple2.Server.Game.Model.Enum;
 namespace Maple2.Server.Game.Model.Field.Actor.ActorState;
 
 public class AnimationState {
-    // TODO: maybe make this a ping based variable?
-    private const long ClientGraceTimeTick = 500; // max time to allow client to go past loop & sequence end
     private readonly IActor actor;
 
     private struct LoopData {
@@ -76,7 +74,7 @@ public class AnimationState {
         sequenceSpeed = 1;
         lastSequenceTime = 0;
         sequenceLoop = new LoopData(0, 0);
-        lastTick =0;
+        lastTick = 0;
         isLooping = false;
         sequenceEnd = 0;
         sequenceType = AnimationType.Misc;
@@ -103,9 +101,7 @@ public class AnimationState {
         sequenceSpeed = speed;
         sequenceType = type;
 
-        long fieldTick = actor.Field.FieldTick;
-
-        lastTick = fieldTick;
+        lastTick = actor.Field.FieldTick;
 
         return true;
     }
@@ -149,7 +145,7 @@ public class AnimationState {
 
         // TODO: maybe make client grace period ping based instead?
         if (isLooping && sequenceLoop.end != 0 && sequenceTime > sequenceLoop.end) {
-            if (!IsPlayerAnimation || tickCount <= sequenceLoopEndTick + ClientGraceTimeTick) {
+            if (!IsPlayerAnimation || tickCount <= sequenceLoopEndTick + Constant.ClientGraceTimeTick) {
                 if (loopOnlyOnce) {
                     isLooping = false;
                     loopOnlyOnce = false;
@@ -168,7 +164,7 @@ public class AnimationState {
         }
 
         if (sequenceEnd != 0 && sequenceTime > sequenceEnd) {
-            if (!IsPlayerAnimation || tickCount <= sequenceEndTick + ClientGraceTimeTick) {
+            if (!IsPlayerAnimation || tickCount <= sequenceEndTick + Constant.ClientGraceTimeTick) {
                 ResetSequence();
             }
         }

--- a/Maple2.Server.Game/Model/Field/Actor/ActorState/AnimationState.cs
+++ b/Maple2.Server.Game/Model/Field/Actor/ActorState/AnimationState.cs
@@ -1,0 +1,233 @@
+﻿using Maple2.Model.Metadata;
+using Maple2.Server.Core.Packets;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using static IronPython.Modules._ast;
+
+namespace Maple2.Server.Game.Model.Field.Actor.ActorState;
+
+public class AnimationState {
+    // TODO: maybe make this a ping based variable?
+    private const long ClientGraceTimeTick = 500; // max time to allow client to go past loop & sequence end
+    private readonly IActor actor;
+
+    public enum Type {
+        Misc,
+        Move,
+        Skill
+    }
+
+    private struct LoopData {
+        public float start;
+        public float end;
+
+        public LoopData(float start, float end) {
+            this.start = start;
+            this.end = end;
+        }
+    }
+
+    public struct TickPair {
+        public long server;
+        public long client;
+
+        // mobs
+        public TickPair(long server) {
+            this.server = server;
+            this.client = server;
+        }
+
+        // players
+        public TickPair(long server, long client) {
+            this.server = server;
+            this.client = client;
+        }
+    }
+
+    public AnimationMetadata? RigMetadata { get; init; }
+    public AnimationSequence? PlayingSequence { get; private set; }
+    public TickPair CastStartTick { get; private set; }
+    public float MoveSpeed { get; set; }
+    public float AttackSpeed { get; set; }
+    private float sequenceSpeed { get; set; }
+    private float lastSequenceTime { get; set; }
+    private float sequenceEnd { get; set; }
+    private LoopData sequenceLoop { get; set; }
+    private long sequenceEndTick { get; set; }
+    private long sequenceLoopEndTick { get; set; }
+    private TickPair lastTick { get; set; }
+    private bool isLooping { get; set; }
+    private bool loopOnlyOnce { get; set; }
+    private Type sequenceType { get; set; }
+
+    private bool debugPrintAnimations;
+    public bool DebugPrintAnimations {
+        get { return debugPrintAnimations; }
+        set {
+            if (actor is FieldPlayer) {
+                debugPrintAnimations = value;
+            }
+        }
+    }
+
+    public AnimationState(IActor actor, string modelName) {
+        this.actor = actor;
+
+        RigMetadata = actor.NpcMetadata.GetAnimation(modelName);
+        MoveSpeed = 1;
+        AttackSpeed = 1;
+    }
+
+    private void ResetSequence() {
+        PlayingSequence = null;
+        CastStartTick = new TickPair(0);
+        sequenceSpeed = 1;
+        lastSequenceTime = 0;
+        sequenceLoop = new LoopData(0, 0);
+        lastTick = new TickPair(0);
+        isLooping = false;
+        sequenceEnd = 0;
+        sequenceType = Type.Misc;
+    }
+
+    public bool TryPlaySequence(string name, float speed, Type type, long clientTick = 0) {
+        if (RigMetadata is null) {
+            return false;
+        }
+
+        bool found = RigMetadata.Sequences.TryGetValue(name, out AnimationSequence? sequence);
+
+        ResetSequence();
+
+        if (!found) {
+            DebugPrint($"Attempt to play nonexistent sequence '{name}' at x{speed} speed, previous: '{PlayingSequence?.Name ?? "none"}' x{sequenceSpeed}");
+
+            return false;
+        }
+
+        DebugPrint($"Playing sequence '{sequence!.Name}' at x{speed} speed, previous: '{PlayingSequence?.Name ?? "none"}' x{sequenceSpeed}");
+
+        PlayingSequence = sequence;
+        sequenceSpeed = speed;
+        sequenceType = type;
+
+        long fieldTick = actor.Field.FieldTick;
+
+        lastTick = new TickPair(fieldTick, clientTick == 0 ? fieldTick : clientTick);
+        CastStartTick = lastTick;
+
+        return true;
+    }
+
+    public void CancelSequence() {
+        if (PlayingSequence is not null) {
+            DebugPrint($"Canceled playing sequence: '{PlayingSequence.Name}' x{sequenceSpeed}");
+        }
+
+        ResetSequence();
+    }
+
+    public void Update(long tickCount) {
+        if (RigMetadata is null) {
+            return;
+        }
+
+        if (PlayingSequence?.Keys is null) {
+
+            ResetSequence();
+
+            return;
+        }
+
+        float sequenceSpeedModifier = sequenceType switch {
+            Type.Move => MoveSpeed,
+            Type.Skill => AttackSpeed,
+            _ => 1
+        };
+
+        long lastServerTick = lastTick.server == 0 ? tickCount : lastTick.server;
+        float speed = sequenceSpeed * sequenceSpeedModifier / 1000;
+        float delta = (float) (tickCount - lastServerTick) * speed;
+        float sequenceTime = lastSequenceTime + delta;
+
+        foreach (AnimationKey key in PlayingSequence.Keys) {
+            if (HasHitKeyframe(sequenceTime, key)) {
+                HitKeyframe(sequenceTime, key, speed);
+            }
+        }
+
+        // TODO: maybe make client grace period ping based instead?
+        if (isLooping && sequenceLoop.end != 0 && sequenceTime > sequenceLoop.end) {
+            if (lastTick.server == lastTick.client || tickCount <= sequenceLoopEndTick + ClientGraceTimeTick) {
+                if (loopOnlyOnce) {
+                    isLooping = false;
+                    loopOnlyOnce = false;
+                }
+
+                sequenceTime -= sequenceLoop.end - sequenceLoop.start;
+                lastSequenceTime = sequenceTime - Math.Max(delta, sequenceTime - sequenceLoop.end + 0.001f);
+
+                // play all keyframe events from loopstart to current
+                foreach (AnimationKey key in PlayingSequence.Keys) {
+                    if (HasHitKeyframe(sequenceTime, key)) {
+                        HitKeyframe(sequenceTime, key, speed);
+                    }
+                }
+            }
+        }
+
+        if (sequenceEnd != 0 && sequenceTime > sequenceEnd) {
+            if (lastTick.server == lastTick.client || tickCount <= sequenceEndTick + ClientGraceTimeTick) {
+                ResetSequence();
+            }
+        }
+
+        lastTick = new TickPair(tickCount, lastTick.client + tickCount - lastTick.server);
+        lastSequenceTime = sequenceTime;
+    }
+
+    public void SetLoopSequence(bool shouldLoop, bool loopOnlyOnce) {
+        isLooping = shouldLoop;
+        this.loopOnlyOnce = loopOnlyOnce;
+    }
+
+    private bool HasHitKeyframe(float sequenceTime, AnimationKey key) {
+        bool keyBeforeLoop = sequenceLoop.end == 0 || key.Time <= sequenceLoop.end + 0.001f;
+        bool hitKeySinceLastTick = key.Time > lastSequenceTime && key.Time <= sequenceTime;
+
+        return keyBeforeLoop && hitKeySinceLastTick;
+    }
+
+    private void HitKeyframe(float sequenceTime, AnimationKey key, float speed) {
+        DebugPrint($"Sequence '{PlayingSequence!.Name}' keyframe event '{key.Name}'");
+
+        actor.KeyframeEvent(key.Name);
+
+        switch(key.Name) {
+            case "loopstart":
+                sequenceLoop = new LoopData(key.Time, 0);
+                break;
+            case "loopend":
+                sequenceLoop = new LoopData(sequenceLoop.start, key.Time);
+                sequenceLoopEndTick = (long)((sequenceTime - key.Time) / speed);
+
+                break;
+            case "end":
+                sequenceEnd = key.Time;
+                sequenceEndTick = (long) ((sequenceTime - key.Time) / speed);
+                break;
+            default:
+                break;
+        }
+    }
+
+    private void DebugPrint(string message) {
+        if (debugPrintAnimations && actor is FieldPlayer player) {
+            player.Session.Send(NoticePacket.Message(message));
+        }
+    }
+}

--- a/Maple2.Server.Game/Model/Field/Actor/FieldActor.cs
+++ b/Maple2.Server.Game/Model/Field/Actor/FieldActor.cs
@@ -32,7 +32,7 @@ internal sealed class FieldActor : IActor {
         Buffs = new BuffManager(this);
         Transform = new Transform();
         NpcMetadata = npcMetadata;
-        AnimationState = new AnimationState(this, "");
+        AnimationState = new AnimationState(this, string.Empty); // not meant to have animations
     }
 
     public void Update(long tickCount) { }

--- a/Maple2.Server.Game/Model/Field/Actor/FieldActor.cs
+++ b/Maple2.Server.Game/Model/Field/Actor/FieldActor.cs
@@ -4,12 +4,15 @@ using Maple2.Server.Game.Manager.Config;
 using Maple2.Server.Game.Manager.Field;
 using Maple2.Tools.VectorMath;
 using Maple2.Tools.Collision;
+using Maple2.Server.Game.Model.Field.Actor.ActorState;
+using Maple2.Database.Storage;
 
 namespace Maple2.Server.Game.Model;
 
 // Dummy Actor for field to own entities.
 internal sealed class FieldActor : IActor {
     public FieldManager Field { get; }
+    public NpcMetadataStorage NpcMetadata { get; init; }
 
     public int ObjectId => 0;
     public bool IsDead => false;
@@ -21,12 +24,15 @@ internal sealed class FieldActor : IActor {
     public Transform Transform { get; init; }
     public BuffManager Buffs { get; }
     public Stats Stats { get; }
+    public AnimationState AnimationState { get; init; }
 
-    public FieldActor(FieldManager field) {
+    public FieldActor(FieldManager field, NpcMetadataStorage npcMetadata) {
         Field = field;
         Stats = new Stats(0, 0);
         Buffs = new BuffManager(this);
         Transform = new Transform();
+        NpcMetadata = npcMetadata;
+        AnimationState = new AnimationState(this, "");
     }
 
     public void Update(long tickCount) { }

--- a/Maple2.Server.Game/Model/Field/Actor/FieldNpc.cs
+++ b/Maple2.Server.Game/Model/Field/Actor/FieldNpc.cs
@@ -91,7 +91,7 @@ public class FieldNpc : Actor<Npc> {
     private int currentWaypointIndex = 0;
 
     public FieldNpc(FieldManager field, int objectId, Agent? agent, Npc npc, string? patrolDataUUID = null) : base(field, objectId, npc, npc.Metadata.Model, field.NpcMetadata) {
-        IdleSequence = npc.Animations.GetValueOrDefault("Idle_A") ?? new AnimationSequence("Idle_A", -1, 1f, null);
+        IdleSequence = npc.Animations.GetValueOrDefault("Idle_A") ?? new AnimationSequence("", -1, 1f, null);
         JumpSequence = npc.Animations.GetValueOrDefault("Jump_A") ?? npc.Animations.GetValueOrDefault("Jump_B");
         WalkSequence = npc.Animations.GetValueOrDefault("Walk_A");
         defaultRoutines = new WeightedSet<string>();

--- a/Maple2.Server.Game/Model/Field/Actor/FieldNpc.cs
+++ b/Maple2.Server.Game/Model/Field/Actor/FieldNpc.cs
@@ -91,7 +91,7 @@ public class FieldNpc : Actor<Npc> {
     private int currentWaypointIndex = 0;
 
     public FieldNpc(FieldManager field, int objectId, Agent? agent, Npc npc, string? patrolDataUUID = null) : base(field, objectId, npc, npc.Metadata.Model, field.NpcMetadata) {
-        IdleSequence = npc.Animations.GetValueOrDefault("Idle_A") ?? new AnimationSequence("", -1, 1f, null);
+        IdleSequence = npc.Animations.GetValueOrDefault("Idle_A") ?? new AnimationSequence(string.Empty, -1, 1f, null);
         JumpSequence = npc.Animations.GetValueOrDefault("Jump_A") ?? npc.Animations.GetValueOrDefault("Jump_B");
         WalkSequence = npc.Animations.GetValueOrDefault("Walk_A");
         defaultRoutines = new WeightedSet<string>();

--- a/Maple2.Server.Game/Model/Field/Actor/FieldNpc.cs
+++ b/Maple2.Server.Game/Model/Field/Actor/FieldNpc.cs
@@ -14,6 +14,7 @@ using Maple2.Tools.Collision;
 using Maple2.Server.Game.Session;
 using Maple2.Server.Game.Model.Field.Actor.ActorState;
 using Maple2.Tools.Extensions;
+using Maple2.Database.Storage;
 
 namespace Maple2.Server.Game.Model;
 
@@ -89,8 +90,8 @@ public class FieldNpc : Actor<Npc> {
     private MS2PatrolData? patrolData;
     private int currentWaypointIndex = 0;
 
-    public FieldNpc(FieldManager field, int objectId, Agent? agent, Npc npc, string? patrolDataUUID = null) : base(field, objectId, npc) {
-        IdleSequence = npc.Animations.GetValueOrDefault("Idle_A") ?? new AnimationSequence(-1, 1f, null);
+    public FieldNpc(FieldManager field, int objectId, Agent? agent, Npc npc, string? patrolDataUUID = null) : base(field, objectId, npc, npc.Metadata.Model, field.NpcMetadata) {
+        IdleSequence = npc.Animations.GetValueOrDefault("Idle_A") ?? new AnimationSequence("Idle_A", -1, 1f, null);
         JumpSequence = npc.Animations.GetValueOrDefault("Jump_A") ?? npc.Animations.GetValueOrDefault("Jump_B");
         WalkSequence = npc.Animations.GetValueOrDefault("Walk_A");
         defaultRoutines = new WeightedSet<string>();

--- a/Maple2.Server.Game/Model/Field/Actor/FieldPlayer.cs
+++ b/Maple2.Server.Game/Model/Field/Actor/FieldPlayer.cs
@@ -1,6 +1,8 @@
 ﻿using System.Numerics;
+using Maple2.Database.Storage;
 using Maple2.Model.Enum;
 using Maple2.Model.Game;
+using Maple2.Server.Core.Packets;
 using Maple2.Server.Game.Packets;
 using Maple2.Server.Game.Session;
 using Maple2.Tools.Collision;
@@ -20,18 +22,29 @@ public class FieldPlayer : Actor<Player> {
     private long battleTick;
     private bool inBattle;
 
+    #region DebugFlags
     private bool debugAi = false;
+    public bool DebugSkills = false;
+    #endregion
 
     public int TagId = 1;
 
     private readonly EventQueue scheduler;
 
-    public FieldPlayer(GameSession session, Player player) : base(session.Field!, player.ObjectId, player) {
+    public FieldPlayer(GameSession session, Player player, NpcMetadataStorage npcMetadata) : base(session.Field!, player.ObjectId, player, GetPlayerModel(player.Character.Gender), npcMetadata) {
         Session = session;
 
         scheduler = new EventQueue();
         scheduler.ScheduleRepeated(() => Field.Broadcast(ProxyObjectPacket.UpdatePlayer(this, 66)), 2000);
         scheduler.Start();
+    }
+
+    private static string GetPlayerModel(Gender gender) {
+        return gender switch {
+            Gender.Male => "male",
+            Gender.Female => "female",
+            _ => ""
+        };
     }
 
     protected override void Dispose(bool disposing) {
@@ -70,10 +83,14 @@ public class FieldPlayer : Actor<Player> {
             InBattle = false;
         }
 
-        Buffs.Update(tickCount);
+        base.Update(tickCount);
     }
 
     protected override void OnDeath() {
         throw new NotImplementedException();
+    }
+
+    public override void KeyframeEvent(long tickCount, long keyTick, string keyName) {
+        
     }
 }

--- a/Maple2.Server.Game/Model/Field/Actor/FieldPlayer.cs
+++ b/Maple2.Server.Game/Model/Field/Actor/FieldPlayer.cs
@@ -43,7 +43,7 @@ public class FieldPlayer : Actor<Player> {
         return gender switch {
             Gender.Male => "male",
             Gender.Female => "female",
-            _ => ""
+            _ => "male"
         };
     }
 

--- a/Maple2.Server.Game/Model/Field/Actor/IActor.cs
+++ b/Maple2.Server.Game/Model/Field/Actor/IActor.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Concurrent;
+using Maple2.Database.Storage;
 using Maple2.Model.Metadata;
 using Maple2.Server.Game.Manager.Config;
+using Maple2.Server.Game.Model.Field.Actor.ActorState;
 using Maple2.Server.Game.Model.Skill;
 using Maple2.Tools.Collision;
 
@@ -8,9 +10,11 @@ namespace Maple2.Server.Game.Model;
 
 public interface IActor : IFieldEntity {
     protected static readonly ConcurrentDictionary<int, Buff> NoBuffs = new();
+    public NpcMetadataStorage NpcMetadata { get; init; }
     public BuffManager Buffs { get; }
 
     public Stats Stats { get; }
+    public AnimationState AnimationState { get; init; }
 
     public bool IsDead { get; }
     public IPrism Shape { get; }
@@ -22,6 +26,7 @@ public interface IActor : IFieldEntity {
     public virtual void TargetAttack(SkillRecord record) { }
 
     public virtual SkillRecord? CastSkill(int id, short level, long uid = 0) { return null; }
+    public virtual void KeyframeEvent(string keyName) { }
 }
 
 public interface IActor<out T> : IActor {

--- a/Maple2.Server.Game/PacketHandlers/SkillHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/SkillHandler.cs
@@ -8,6 +8,7 @@ using Maple2.Server.Core.Constants;
 using Maple2.Server.Core.PacketHandlers;
 using Maple2.Server.Core.Packets;
 using Maple2.Server.Game.Model;
+using Maple2.Server.Game.Model.Enum;
 using Maple2.Server.Game.Model.Field.Actor.ActorState;
 using Maple2.Server.Game.Model.Skill;
 using Maple2.Server.Game.Packets;
@@ -134,7 +135,7 @@ public class SkillHandler : PacketHandler<GameSession> {
 
         SkillMetadataMotionProperty motion = metadata.Data.Motions[0].MotionProperty;
 
-        session.Player.AnimationState.TryPlaySequence(motion.SequenceName, motion.SequenceSpeed, AnimationState.Type.Skill);
+        session.Player.AnimationState.TryPlaySequence(motion.SequenceName, motion.SequenceSpeed, AnimationType.Skill);
 
         foreach (SkillEffectMetadata effect in metadata.Data.Skills) {
             session.Player.ApplyEffect(session.Player, session.Player, effect);
@@ -334,7 +335,7 @@ public class SkillHandler : PacketHandler<GameSession> {
 
         SkillMetadataMotionProperty motion = record.Metadata.Data.Motions[motionPoint].MotionProperty;
 
-        session.Player.AnimationState.TryPlaySequence(motion.SequenceName, motion.SequenceSpeed, AnimationState.Type.Skill);
+        session.Player.AnimationState.TryPlaySequence(motion.SequenceName, motion.SequenceSpeed, AnimationType.Skill);
     }
 
     private void HandleTickSync(GameSession session, IByteReader packet) {

--- a/Maple2.Server.Game/PacketHandlers/SkillHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/SkillHandler.cs
@@ -8,6 +8,7 @@ using Maple2.Server.Core.Constants;
 using Maple2.Server.Core.PacketHandlers;
 using Maple2.Server.Core.Packets;
 using Maple2.Server.Game.Model;
+using Maple2.Server.Game.Model.Field.Actor.ActorState;
 using Maple2.Server.Game.Model.Skill;
 using Maple2.Server.Game.Packets;
 using Maple2.Server.Game.Session;
@@ -109,6 +110,13 @@ public class SkillHandler : PacketHandler<GameSession> {
         if (record.IsHold) {
             record.HoldInt = packet.ReadInt();
             record.HoldString = packet.ReadUnicodeString();
+
+            if (session.Player.DebugSkills) {
+                session.Send(NoticePacket.Message($"Skill.Use: {skillId}, {skillUid}; IsHold: true; HoldInt: {record.HoldInt}; HoldString: {record.HoldString}; UnkBool: {record.Unknown}"));
+            }
+        }
+        else if (session.Player.DebugSkills) {
+            session.Send(NoticePacket.Message($"Skill.Use: {skillId}, {skillUid}; IsHold: false; UnkBool: {record.Unknown}"));
         }
 
         if (itemUid > 0) {
@@ -123,6 +131,10 @@ public class SkillHandler : PacketHandler<GameSession> {
         session.Player.InBattle = itemUid <= 0;
         session.ActiveSkills.Add(record);
         session.Field?.Broadcast(SkillPacket.Use(record));
+
+        SkillMetadataMotionProperty motion = metadata.Data.Motions[0].MotionProperty;
+
+        session.Player.AnimationState.TryPlaySequence(motion.SequenceName, motion.SequenceSpeed, AnimationState.Type.Skill);
 
         foreach (SkillEffectMetadata effect in metadata.Data.Skills) {
             session.Player.ApplyEffect(session.Player, session.Player, effect);
@@ -147,6 +159,10 @@ public class SkillHandler : PacketHandler<GameSession> {
 
         record.Position = packet.Read<Vector3>();
         record.Direction = packet.Read<Vector3>();
+
+        if (session.Player.DebugSkills) {
+            session.Send(NoticePacket.Message($"Skill.Attack.Point: {skillUid}; AttackPoint: {attackPoint}"));
+        }
 
         byte count = packet.ReadByte();
         // Note: counts up for skills that are held down (reused skillUid)
@@ -211,6 +227,10 @@ public class SkillHandler : PacketHandler<GameSession> {
             Logger.Error("Unhandled skill-Target value2({Value}): {Record}", unknown2, record);
         }
 
+        if (session.Player.DebugSkills) {
+            session.Send(NoticePacket.Message($"Skill.Attack.Damage: {skillUid}; AttackPoint: {attackPoint}"));
+        }
+
         for (byte i = 0; i < count; i++) {
             int targetId = packet.ReadInt();
             packet.ReadByte();
@@ -265,6 +285,10 @@ public class SkillHandler : PacketHandler<GameSession> {
             Logger.Error("Unhandled skill-MagicPath value2({Value}): {Record}", unknown2, record);
         }
 
+        if (session.Player.DebugSkills) {
+            session.Send(NoticePacket.Message($"Skill.Attack.Region: {skillUid}; AttackPoint: {attackPoint}; UnkInt: {unknown1}; UnkInt: {unknown2}"));
+        }
+
         record.Position = packet.Read<Vector3>();
         record.Rotation = packet.Read<Vector3>();
 
@@ -279,8 +303,38 @@ public class SkillHandler : PacketHandler<GameSession> {
             Logger.Warning("Invalid Sync Skill {SkillUid}", skillUid);
             return;
         }
+        int skillId = packet.ReadInt();
+        short skillLevel = packet.ReadShort();
+        byte motionPoint = packet.ReadByte();
+
+        if (record.Metadata.Data.Motions.Length >= motionPoint) {
+            Logger.Warning($"Invalid motion point {motionPoint} for {record}", skillUid);
+            return;
+        }
+
+        if (session.Player.AnimationState.PlayingSequence is null) {
+            Logger.Warning($"Last motion already expired on skill {skillUid}");
+        }
+
+        record.TrySetMotionPoint(motionPoint);
+
+        Vector3 position = packet.Read<Vector3>();
+        Vector3 unk = packet.Read<Vector3>(); // either velocity or direction
+        Vector3 rotation = packet.Read<Vector3>();
+        Vector3 input = packet.Read<Vector3>(); // x and y match with wasd/arrow input, not normalized
+        bool toggle = packet.ReadByte() == 1;
+        int unk3 = packet.ReadInt();
+        byte unk4 = packet.ReadByte();
 
         session.Field?.Broadcast(SkillPacket.Sync(record), session);
+
+        if (session.Player.DebugSkills) {
+            session.Send(NoticePacket.Message($"Skill.Sync: {skillId},{skillUid}; AttackPoint: {motionPoint}; Toggle: {toggle}; UnkInt: {unk3}; UnkByte: {unk4}; UnkVec: {unk}"));
+        }
+
+        SkillMetadataMotionProperty motion = record.Metadata.Data.Motions[motionPoint].MotionProperty;
+
+        session.Player.AnimationState.TryPlaySequence(motion.SequenceName, motion.SequenceSpeed, AnimationState.Type.Skill);
     }
 
     private void HandleTickSync(GameSession session, IByteReader packet) {
@@ -292,6 +346,20 @@ public class SkillHandler : PacketHandler<GameSession> {
         }
 
         record.ServerTick = packet.ReadInt();
+
+        if (session.Player.DebugSkills) {
+            session.Send(NoticePacket.Message($"Skill.SyncTick: {skillUid}"));
+        }
+
+        string skillSequence = record.Motion.MotionProperty.SequenceName;
+        string playingSequence = session.Player.AnimationState.PlayingSequence?.Name ?? "";
+
+        if (skillSequence != playingSequence) {
+            Logger.Warning($"Motion point on skill cast {skillUid} '{skillSequence}' doesn't match playing sequence '{playingSequence}'", skillUid);
+            return;
+        }
+
+        session.Player.AnimationState.SetLoopSequence(true, true);
     }
 
     private void HandleCancel(GameSession session, IByteReader packet) {
@@ -304,5 +372,11 @@ public class SkillHandler : PacketHandler<GameSession> {
 
         session.Player.InBattle = true;
         session.Field?.Broadcast(SkillPacket.Cancel(record), session);
+
+        if (session.Player.DebugSkills) {
+            session.Send(NoticePacket.Message($"Skill.Cancel: {skillUid}"));
+        }
+
+        session.Player.AnimationState.CancelSequence();
     }
 }

--- a/Maple2.Server.Game/Session/GameSession.cs
+++ b/Maple2.Server.Game/Session/GameSession.cs
@@ -124,7 +124,7 @@ public sealed partial class GameSession : Core.Network.Session {
         }
         db.Commit();
 
-        Player = new FieldPlayer(this, player);
+        Player = new FieldPlayer(this, player, NpcMetadata);
         Currency = new CurrencyManager(this);
         Mastery = new MasteryManager(this, Lua);
         Stats = new StatsManager(this);


### PR DESCRIPTION
Used for dependOnCasterState in in region skills like echoing blades, and requireSkillCodes in additional effects like for Squall for players. Used for pretty much every animation in mobs to get the timing correct. Required to properly schedule attack points in mob skill casts & to schedule mob skills that move the mobs.