### PR TITLE
Fix patrolData clearing early

### DIFF
--- a/Maple2.Server.Game/Model/Field/Actor/FieldNpc.cs
+++ b/Maple2.Server.Game/Model/Field/Actor/FieldNpc.cs
@@ -178,7 +178,7 @@ public class FieldNpc : Actor<Npc> {
                 }
             }
 
-            if (currentWaypointIndex + 1 >= patrolData.WayPoints.Count && !patrolData.IsLoop) {
+            if (currentWaypointIndex + 1 > patrolData.WayPoints.Count && !patrolData.IsLoop) {
                 patrolData = null;
                 return new WaitRoutine(this, IdleSequence.Id, 1f);
             }
@@ -351,6 +351,21 @@ public class FieldNpc : Actor<Npc> {
 
     public void SetPatrolData(MS2PatrolData newPatrolData) {
         patrolData = newPatrolData;
+        currentWaypointIndex = 0;
+    }
+
+    public void CheckPatrolSequence() {
+        if (patrolData is null) {
+            return;
+        }
+
+        // make sure we're at the last checkpoint in the list
+        if (currentWaypointIndex + 1 < patrolData.WayPoints.Count) {
+            return;
+        }
+
+        // Clear patrol data
+        patrolData = null;
         currentWaypointIndex = 0;
     }
 }

--- a/Maple2.Server.Game/Model/Field/Actor/Routine/MoveRoutine.cs
+++ b/Maple2.Server.Game/Model/Field/Actor/Routine/MoveRoutine.cs
@@ -4,7 +4,7 @@ using Maple2.Tools.Extensions;
 namespace Maple2.Server.Game.Model.Routine;
 
 public class MoveRoutine : NpcRoutine {
-    private const float MIN_DISTANCE = 50f;
+    private const float MIN_DISTANCE = 25f;
 
     public static NpcRoutine Walk(FieldNpc npc, short sequenceId) {
         try {
@@ -77,5 +77,6 @@ public class MoveRoutine : NpcRoutine {
         segmentTime = TimeSpan.Zero;
         Npc.Velocity = default;
         Npc.Navigation?.UpdatePosition();
+        Npc.CheckPatrolSequence();
     }
 }


### PR DESCRIPTION
I changed move slide distance to 25.0 because n*x** loves to put their waypoints on the edges of detection boxes, and movement would end right before they hit the trigger. Maybe we should use a dynamic value based on if it's a waypoint or randomized patrol.