### PR TITLE
fix: NA gacha boxes

### DIFF
--- a/Maple2.File.Ingest/Maple2.File.Ingest.csproj
+++ b/Maple2.File.Ingest/Maple2.File.Ingest.csproj
@@ -20,7 +20,7 @@
         <PackageReference Include="Crc32.NET" Version="1.2.0" />
         <PackageReference Include="CsvHelper" Version="32.0.2" />
         <PackageReference Include="DotNetZip" Version="1.16.0" />
-        <PackageReference Include="Maple2.File.Parser.Tadeucci" Version="2.1.9" />
+        <PackageReference Include="Maple2.File.Parser.Tadeucci" Version="2.1.12" />
         <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="7.0.0" />
     </ItemGroup>
 

--- a/Maple2.File.Ingest/Mapper/ServerTableMapper.cs
+++ b/Maple2.File.Ingest/Mapper/ServerTableMapper.cs
@@ -510,14 +510,27 @@ public class ServerTableMapper : TypeMapper<ServerTableMetadata> {
                 foreach (IndividualItemDrop.Group.Item item in group.v) {
                     int minCount = item.minCount <= 0 ? 1 : item.minCount;
                     int maxCount = item.maxCount < item.minCount ? item.minCount : item.maxCount;
+                    List<IndividualDropItemTable.Item.Rarity> rarities = item.gradeProbability
+                        .Select((probability, i) => new IndividualDropItemTable.Item.Rarity(probability, item.grade[i]))
+                        .ToList();
+
+                    if (rarities.Count == 0) {
+                        if (item.grade.Length > 0) {
+                            foreach (short grade in item.grade) {
+                                rarities.Add(new IndividualDropItemTable.Item.Rarity(100, grade));
+                            }
+                        } else if (item.uiItemRank != 0) {
+                            rarities.Add(new IndividualDropItemTable.Item.Rarity(100, item.uiItemRank));
+                        }
+                    }
                     items.Add(new IndividualDropItemTable.Item(
-                        Ids: new[] { item.itemID, item.itemID2 },
+                        Ids: [item.itemID, item.itemID2],
                         Announce: item.isAnnounce,
                         ProperJobWeight: item.properJobWeight,
                         ImproperJobWeight: item.imProperJobWeight,
                         Weight: item.weight,
                         DropCount: new IndividualDropItemTable.Range<int>(minCount, maxCount),
-                        Rarities: item.gradeProbability.Select((probability, i) => new IndividualDropItemTable.Item.Rarity(probability, item.grade[i])).ToList(),
+                        Rarities: rarities,
                         EnchantLevel: item.enchantLevel,
                         SocketDataId: item.socketDataID,
                         DeductTradeCount: item.tradableCountDeduction,

--- a/Maple2.Server.Game/Manager/Items/InventoryManager.cs
+++ b/Maple2.Server.Game/Manager/Items/InventoryManager.cs
@@ -223,6 +223,13 @@ public class InventoryManager {
                         return false;
                     }
 
+                    if (add.Metadata.Property.SlotMax == 1 && add.Amount > 1) {
+                        add.Amount--;
+                        if (!Add(add, notifyNew, commit)) {
+                            return false;
+                        }
+                    }
+
                     using GameStorage.Request db = session.GameStorage.Context();
                     Item? newAdd = db.CreateItem(session.CharacterId, add);
                     if (newAdd == null) {

--- a/Maple2.Server.Game/Manager/QuestManager.cs
+++ b/Maple2.Server.Game/Manager/QuestManager.cs
@@ -308,7 +308,8 @@ public sealed class QuestManager {
             if (!session.ItemMetadata.TryGet(entry.Id, out ItemMetadata? metadata)) {
                 continue;
             }
-            if (metadata.Limit.JobRecommends.Length > 0 && !metadata.Limit.JobRecommends.Contains(session.Player.Value.Character.Job.Code())) {
+            if (metadata.Limit.JobRecommends.Length > 0 && !metadata.Limit.JobRecommends.Contains(JobCode.None)
+                && !metadata.Limit.JobRecommends.Contains(session.Player.Value.Character.Job.Code())) {
                 continue;
             }
             Item? item = session.Field.ItemDrop.CreateItem(entry.Id, entry.Rarity, entry.Amount);


### PR DESCRIPTION
Fixes boxes like Superlative. It uses the new Server.m2d from https://github.com/Zintixx/MapleStory2-XML/releases/tag/v1.0.1

- Properly set rarity for box content
- Only give items of class if smartDropRate is used
- If item doesn't stack and it has more than 1 **Amount**, give multiple items
- Fix navigator quests job limit to accept _None_
- Fixes https://github.com/AngeloTadeucci/Maple2/issues/88