### PR TITLE
Feat: dynamic channel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,8 +17,8 @@ GAME_DB_NAME=game-server
 GAME_IP=localhost
 LOGIN_IP=localhost
 
-GRPC_WORDL_IP=localhost
-GRPC_WORDL_PORT=21001
+GRPC_WORLD_IP=localhost
+GRPC_WORLD_PORT=21001
 
 WEB_IP=localhost
 WEB_PORT=4000

--- a/.env.example
+++ b/.env.example
@@ -15,10 +15,10 @@ GAME_DB_NAME=game-server
 # Maple2.Server - Only needed if hosting for external access
 
 GAME_IP=localhost
-GAME_CHANNEL=1
-GAME_PORT=20002
 LOGIN_IP=localhost
-GRPC_CHANNEL_PORT=21002
+
+GRPC_WORDL_IP=localhost
+GRPC_WORDL_PORT=21001
 
 WEB_IP=localhost
 WEB_PORT=4000

--- a/Maple2.Server.Core/Constants/Target.cs
+++ b/Maple2.Server.Core/Constants/Target.cs
@@ -11,13 +11,15 @@ public static class Target {
     public static readonly ushort LoginPort = 20001;
 
     public static readonly IPAddress GameIp = IPAddress.Loopback;
-    public static readonly ushort GamePort = 20002;
-    public static readonly short GameChannel = 1;
+    public static readonly ushort BaseGamePort = 20002;
 
     public static readonly Uri WebUri = new("http://localhost");
 
+    public static readonly IPAddress GrpcWorldIp = IPAddress.Loopback;
     public static readonly ushort GrpcWorldPort = 21001;
-    public static readonly ushort GrpcChannelPort = 21002;
+    public static readonly Uri GrpcWorldUri = new($"http://{GrpcWorldIp}:{GrpcWorldPort}");
+
+    public static readonly ushort BaseGrpcChannelPort = 21002;
 
     static Target() {
         if (IPAddress.TryParse(Environment.GetEnvironmentVariable("LOGIN_IP"), out IPAddress? loginIpAddress)) {
@@ -30,19 +32,16 @@ public static class Target {
         if (IPAddress.TryParse(Environment.GetEnvironmentVariable("GAME_IP"), out IPAddress? gameIpAddress)) {
             GameIp = gameIpAddress;
         }
-        if (ushort.TryParse(Environment.GetEnvironmentVariable("GAME_PORT"), out ushort gamePortOverride)) {
-            GamePort = gamePortOverride;
-        }
-        if (short.TryParse(Environment.GetEnvironmentVariable("GAME_CHANNEL"), out short gameChannel)) {
-            GameChannel = gameChannel;
+
+        if (IPAddress.TryParse(Environment.GetEnvironmentVariable("GRPC_WORLD_IP"), out IPAddress? grpcWorldIpOverride)) {
+            GrpcWorldIp = grpcWorldIpOverride;
         }
 
         if (ushort.TryParse(Environment.GetEnvironmentVariable("GRPC_WORLD_PORT"), out ushort grpcWorldPortOverride)) {
             GrpcWorldPort = grpcWorldPortOverride;
         }
-        if (ushort.TryParse(Environment.GetEnvironmentVariable("GRPC_CHANNEL_PORT"), out ushort grpcChannelPortOverride)) {
-            GrpcChannelPort = grpcChannelPortOverride;
-        }
+
+        GrpcWorldUri = new Uri($"http://{GrpcWorldIp}:{GrpcWorldPort}");
 
         string webIP = Environment.GetEnvironmentVariable("WEB_IP") ?? "localhost";
         string webPort = Environment.GetEnvironmentVariable("WEB_PORT") ?? "4000";

--- a/Maple2.Server.Core/proto/world/world.proto
+++ b/Maple2.Server.Core/proto/world/world.proto
@@ -44,6 +44,8 @@ service World {
   rpc BlackMarket(BlackMarketRequest) returns (BlackMarketResponse);
   // Time Events
   rpc TimeEvent(TimeEventRequest) returns (TimeEventResponse);
+  // Port management
+  rpc Port(PortRequest) returns (PortResponse);
 }
 
 enum Server {
@@ -457,4 +459,14 @@ message GlobalPortalInfo {
   int32 instance_id = 4;
   int32 map_id = 5;
   int32 portal_id = 6;
+}
+
+message PortRequest {
+  string game_ip = 1;
+}
+
+message PortResponse {
+  int32 game_port = 1;
+  int32 grpc_port = 2;
+  int32 game_channel = 3;
 }

--- a/Maple2.Server.Core/proto/world/world.proto
+++ b/Maple2.Server.Core/proto/world/world.proto
@@ -44,8 +44,8 @@ service World {
   rpc BlackMarket(BlackMarketRequest) returns (BlackMarketResponse);
   // Time Events
   rpc TimeEvent(TimeEventRequest) returns (TimeEventResponse);
-  // Port management
-  rpc Port(PortRequest) returns (PortResponse);
+  // Add channel
+  rpc AddChannel(AddChannelRequest) returns (AddChannelResponse);
 }
 
 enum Server {
@@ -461,11 +461,11 @@ message GlobalPortalInfo {
   int32 portal_id = 6;
 }
 
-message PortRequest {
+message AddChannelRequest {
   string game_ip = 1;
 }
 
-message PortResponse {
+message AddChannelResponse {
   int32 game_port = 1;
   int32 grpc_port = 2;
   int32 game_channel = 3;

--- a/Maple2.Server.Game/GameServer.cs
+++ b/Maple2.Server.Game/GameServer.cs
@@ -26,11 +26,11 @@ public class GameServer : Server<GameSession> {
     private Dictionary<int, Dictionary<int, ShopItem>> shopItemCache;
     private readonly GameStorage gameStorage;
 
-    private static int _channel = 0;
+    private static short _channel = 0;
 
     public GameServer(FieldManager.Factory fieldFactory, PacketRouter<GameSession> router, IComponentContext context, GameStorage gameStorage, ServerTableMetadataStorage serverTableMetadataStorage, int port, int channel)
             : base((ushort) port, router, context, serverTableMetadataStorage) {
-        _channel = channel;
+        _channel = (short) channel;
         this.fieldFactory = fieldFactory;
         connectingSessions = [];
         sessions = new Dictionary<long, GameSession>();
@@ -207,7 +207,7 @@ public class GameServer : Server<GameSession> {
         }
     }
 
-    public static int GetChannel() {
+    public static short GetChannel() {
         return _channel;
     }
 }

--- a/Maple2.Server.Game/GameServer.cs
+++ b/Maple2.Server.Game/GameServer.cs
@@ -8,7 +8,6 @@ using Maple2.Model.Game;
 using Maple2.Model.Game.Event;
 using Maple2.PacketLib.Tools;
 using Maple2.Model.Game.Shop;
-using Maple2.Server.Core.Constants;
 using Maple2.Server.Core.Network;
 using Maple2.Server.Core.Packets;
 using Maple2.Server.Game.Manager.Field;
@@ -27,10 +26,11 @@ public class GameServer : Server<GameSession> {
     private Dictionary<int, Dictionary<int, ShopItem>> shopItemCache;
     private readonly GameStorage gameStorage;
 
-    public int Channel => Target.GameChannel;
+    private static int _channel = 0;
 
-    public GameServer(FieldManager.Factory fieldFactory, PacketRouter<GameSession> router, IComponentContext context, GameStorage gameStorage, ServerTableMetadataStorage serverTableMetadataStorage)
-            : base(Target.GamePort, router, context, serverTableMetadataStorage) {
+    public GameServer(FieldManager.Factory fieldFactory, PacketRouter<GameSession> router, IComponentContext context, GameStorage gameStorage, ServerTableMetadataStorage serverTableMetadataStorage, int port, int channel)
+            : base((ushort) port, router, context, serverTableMetadataStorage) {
+        _channel = channel;
         this.fieldFactory = fieldFactory;
         connectingSessions = [];
         sessions = new Dictionary<long, GameSession>();
@@ -205,5 +205,9 @@ public class GameServer : Server<GameSession> {
         foreach (GameSession session in sessions.Values) {
             session.Send(packet);
         }
+    }
+
+    public static int GetChannel() {
+        return _channel;
     }
 }

--- a/Maple2.Server.Game/Program.cs
+++ b/Maple2.Server.Game/Program.cs
@@ -38,11 +38,11 @@ CultureInfo.CurrentCulture = new("en-US");
 
 DotEnv.Load();
 
-PortResponse? response = null;
+AddChannelResponse? response = null;
 try {
     GrpcChannel channel = GrpcChannel.ForAddress(Target.GrpcWorldUri);
     var worldClient = new WorldClient(channel);
-    response = worldClient.Port(new PortRequest {
+    response = worldClient.AddChannel(new AddChannelRequest {
         GameIp = Target.GameIp.ToString(),
     });
 

--- a/Maple2.Server.Game/Program.cs
+++ b/Maple2.Server.Game/Program.cs
@@ -5,6 +5,9 @@ using System.Reflection;
 using Autofac;
 using Autofac.Extensions.DependencyInjection;
 using Autofac.Features.AttributeFilters;
+using Grpc.Core;
+using Grpc.Net.Client;
+using Maple2.Database.Storage;
 using Maple2.Lua;
 using Maple2.Server.Core.Constants;
 using Maple2.Server.Core.Modules;
@@ -17,6 +20,7 @@ using Maple2.Server.Game.Service;
 using Maple2.Server.Game.Session;
 using Maple2.Server.Game.Util;
 using Maple2.Server.Game.Util.Sync;
+using Maple2.Server.World.Service;
 using Maple2.Tools;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -27,11 +31,25 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Serilog;
+using WorldClient = Maple2.Server.World.Service.World.WorldClient;
 
 // Force Globalization to en-US because we use periods instead of commas for decimals
 CultureInfo.CurrentCulture = new("en-US");
 
 DotEnv.Load();
+
+PortResponse? response = null;
+try {
+    GrpcChannel channel = GrpcChannel.ForAddress(Target.GrpcWorldUri);
+    var worldClient = new WorldClient(channel);
+    response = worldClient.Port(new PortRequest {
+        GameIp = Target.GameIp.ToString(),
+    });
+
+} catch (RpcException e) {
+    Log.Error(e, "Failed to get port information from World Server. Is World Server running?");
+    return;
+}
 
 IConfigurationRoot configRoot = new ConfigurationBuilder()
     .SetBasePath(Directory.GetCurrentDirectory())
@@ -43,7 +61,7 @@ Log.Logger = new LoggerConfiguration()
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 builder.WebHost.UseKestrel(options => {
-    options.Listen(new IPEndPoint(IPAddress.Any, Target.GrpcChannelPort), listen => {
+    options.Listen(new IPEndPoint(IPAddress.Any, response.GrpcPort), listen => {
         listen.Protocols = HttpProtocols.Http2;
     });
 });
@@ -54,7 +72,15 @@ builder.Logging.AddSerilog(dispose: true);
 
 builder.Services.AddGrpc();
 builder.Services.RegisterModule<WorldClientModule>();
-builder.Services.AddSingleton<GameServer>();
+builder.Services.AddSingleton<GameServer>(provider => new GameServer(
+    provider.GetRequiredService<FieldManager.Factory>(),
+    provider.GetRequiredService<PacketRouter<GameSession>>(),
+    provider.GetRequiredService<IComponentContext>(),
+    provider.GetRequiredService<GameStorage>(),
+    provider.GetRequiredService<ServerTableMetadataStorage>(),
+    response.GamePort,
+    response.GameChannel
+));
 builder.Services.AddHostedService<GameServer>(provider => provider.GetService<GameServer>()!);
 
 builder.Services.AddGrpcHealthChecks();

--- a/Maple2.Server.Game/Service/ChannelService.Buddy.cs
+++ b/Maple2.Server.Game/Service/ChannelService.Buddy.cs
@@ -30,6 +30,6 @@ public partial class ChannelService {
                 break;
         }
 
-        return Task.FromResult(new BuddyResponse { Channel = session.Channel });
+        return Task.FromResult(new BuddyResponse { Channel = GameServer.GetChannel() });
     }
 }

--- a/Maple2.Server.Game/Session/GameSession.cs
+++ b/Maple2.Server.Game/Session/GameSession.cs
@@ -3,7 +3,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Net.Sockets;
 using System.Numerics;
 using Autofac;
-using Community.CsharpSqlite;
 using Grpc.Core;
 using Maple2.Database.Extensions;
 using Maple2.Database.Storage;
@@ -48,7 +47,6 @@ public sealed partial class GameSession : Core.Network.Session {
     public long CharacterId { get; private set; }
     public string PlayerName => Player.Value.Character.Name;
     public Guid MachineId { get; private set; }
-    public int Channel;
 
     #region Autofac Autowired
     // ReSharper disable MemberCanBePrivate.Global
@@ -104,7 +102,6 @@ public sealed partial class GameSession : Core.Network.Session {
         CommandHandler = context.Resolve<CommandRouter>(new NamedParameter("session", this));
         Scheduler = new EventQueue();
         Scheduler.ScheduleRepeated(() => Send(TimeSyncPacket.Request()), 1000);
-        Channel = Target.GameChannel;
 
         OnLoop += Scheduler.InvokeAll;
         GroupChats = new ConcurrentDictionary<int, GroupChatManager>();
@@ -119,7 +116,6 @@ public sealed partial class GameSession : Core.Network.Session {
         AccountId = accountId;
         CharacterId = characterId;
         MachineId = machineId;
-        Channel = channel;
 
         State = SessionState.ChangeMap;
         server.OnConnected(this);
@@ -127,7 +123,7 @@ public sealed partial class GameSession : Core.Network.Session {
         using GameStorage.Request db = GameStorage.Context();
         db.BeginTransaction();
         int objectId = FieldManager.NextGlobalId();
-        Player? player = db.LoadPlayer(AccountId, CharacterId, objectId, (short) Channel);
+        Player? player = db.LoadPlayer(AccountId, CharacterId, objectId, (short) GameServer.GetChannel());
         if (player == null) {
             Logger.Warning("Failed to load player from database: {AccountId}, {CharacterId}", AccountId, CharacterId);
             Send(MigrationPacket.MoveResult(MigrationError.s_move_err_default));
@@ -390,6 +386,10 @@ public sealed partial class GameSession : Core.Network.Session {
         Send(PremiumCubPacket.LoadItems(Player.Value.Account.PremiumRewardsClaimed));
         ConditionUpdate(ConditionType.map, codeLong: Player.Value.Character.MapId);
         ConditionUpdate(ConditionType.job_change, codeLong: (int) Player.Value.Character.Job.Code());
+
+        // Update the client with the latest channel list.
+        ChannelsResponse response = World.Channels(new ChannelsRequest());
+        Send(ChannelPacket.Dynamic(response.Channels));
         return true;
     }
 

--- a/Maple2.Server.Game/Session/GameSession.cs
+++ b/Maple2.Server.Game/Session/GameSession.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
+using System.Net;
 using System.Net.Sockets;
 using System.Numerics;
 using Autofac;
@@ -390,6 +391,7 @@ public sealed partial class GameSession : Core.Network.Session {
         // Update the client with the latest channel list.
         ChannelsResponse response = World.Channels(new ChannelsRequest());
         Send(ChannelPacket.Dynamic(response.Channels));
+        Send(ServerListPacket.Load(Target.SERVER_NAME, [new IPEndPoint(Target.LoginIp, Target.LoginPort)], response.Channels));
         return true;
     }
 

--- a/Maple2.Server.Game/Session/GameSession.cs
+++ b/Maple2.Server.Game/Session/GameSession.cs
@@ -124,7 +124,7 @@ public sealed partial class GameSession : Core.Network.Session {
         using GameStorage.Request db = GameStorage.Context();
         db.BeginTransaction();
         int objectId = FieldManager.NextGlobalId();
-        Player? player = db.LoadPlayer(AccountId, CharacterId, objectId, (short) GameServer.GetChannel());
+        Player? player = db.LoadPlayer(AccountId, CharacterId, objectId, GameServer.GetChannel());
         if (player == null) {
             Logger.Warning("Failed to load player from database: {AccountId}, {CharacterId}", AccountId, CharacterId);
             Send(MigrationPacket.MoveResult(MigrationError.s_move_err_default));

--- a/Maple2.Server.Login/Session/LoginSession.cs
+++ b/Maple2.Server.Login/Session/LoginSession.cs
@@ -59,8 +59,7 @@ public class LoginSession : Core.Network.Session {
     public void ListServers() {
         ChannelsResponse response = World.Channels(new ChannelsRequest());
         Send(BannerListPacket.Load(Server.GetSystemBanners()));
-        Send(ServerListPacket.Load(Target.SERVER_NAME,
-            new[] { new IPEndPoint(Target.LoginIp, Server.Port) }, response.Channels));
+        Send(ServerListPacket.Load(Target.SERVER_NAME, [new IPEndPoint(Target.LoginIp, Target.LoginPort)], response.Channels));
     }
 
     public void ListCharacters() {

--- a/Maple2.Server.World/Containers/ChannelClientLookup.cs
+++ b/Maple2.Server.World/Containers/ChannelClientLookup.cs
@@ -137,7 +137,7 @@ public class ChannelClientLookup : IEnumerable<(int, ChannelClient)> {
                 if (ex.Status.StatusCode != StatusCode.Unavailable) {
                     logger.Warning("{Error} monitoring channel {Channel}", ex.Message, channel);
                 }
-                if (activeChannels[i] is ChannelStatus.Active or ChannelStatus.Pending) {
+                if (activeChannels[i] is ChannelStatus.Active) {
                     logger.Information("Channel {Channel} has become inactive", channel);
                 }
                 activeChannels[i] = ChannelStatus.Inactive;

--- a/Maple2.Server.World/Program.cs
+++ b/Maple2.Server.World/Program.cs
@@ -81,6 +81,14 @@ app.MapGet("/", () => "Communication with gRPC endpoints must be made through a 
 app.MapGrpcService<WorldService>();
 app.MapGrpcService<GlobalService>();
 
+IHostApplicationLifetime lifetime = app.Lifetime;
+lifetime.ApplicationStopping.Register(() => {
+    Log.Information("WorldServer stopping");
+    WorldServer world = app.Services.GetRequiredService<WorldServer>();
+    world.Stop();
+    lifetime.StopApplication();
+});
+
 
 ILifetimeScope root = app.Services.GetAutofacRoot();
 var gameStorage = root.Resolve<GameStorage>();

--- a/Maple2.Server.World/Service/WorldService.GamePorts.cs
+++ b/Maple2.Server.World/Service/WorldService.GamePorts.cs
@@ -4,10 +4,10 @@ using Grpc.Core;
 namespace Maple2.Server.World.Service;
 
 public partial class WorldService {
-    public override Task<PortResponse> Port(PortRequest request, ServerCallContext context) {
+    public override Task<AddChannelResponse> AddChannel(AddChannelRequest request, ServerCallContext context) {
         (ushort gamePort, int grpcPort, int channel) = channelClients.FindOrCreateChannelByIp(request.GameIp);
 
-        return Task.FromResult(new PortResponse {
+        return Task.FromResult(new AddChannelResponse {
             GamePort = gamePort,
             GrpcPort = grpcPort,
             GameChannel = channel

--- a/Maple2.Server.World/Service/WorldService.GamePorts.cs
+++ b/Maple2.Server.World/Service/WorldService.GamePorts.cs
@@ -1,4 +1,4 @@
-
+﻿
 using Grpc.Core;
 
 namespace Maple2.Server.World.Service;

--- a/Maple2.Server.World/Service/WorldService.GamePorts.cs
+++ b/Maple2.Server.World/Service/WorldService.GamePorts.cs
@@ -1,0 +1,16 @@
+
+using Grpc.Core;
+
+namespace Maple2.Server.World.Service;
+
+public partial class WorldService {
+    public override Task<PortResponse> Port(PortRequest request, ServerCallContext context) {
+        (ushort gamePort, int grpcPort, int channel) = channelClients.FindOrCreateChannelByIp(request.GameIp);
+
+        return Task.FromResult(new PortResponse {
+            GamePort = gamePort,
+            GrpcPort = grpcPort,
+            GameChannel = channel
+        });
+    }
+}


### PR DESCRIPTION
- Resolves #53 

Now GameServer asks WorldServer for an available port before initializing. WorldServer searches for an inactive channel with the same IP, if it exists it'll return the existing channel id and ports. If it doesn't exist it'll create a new channel.

Joining a map or trying to migrate to an unavailable channel will update the channel list.

The amount of channels now is also dynamic.

Fixed WorldServer not shutting down because of active threads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Integrated gRPC communication for improved server coordination.
  - Added dynamic channel list updates for client sessions.
  
- **Bug Fixes**
  - Enhanced error handling and logging for channel operations.

- **Performance Enhancements**
  - Optimized channel lookup with the use of lists instead of arrays.

- **Refactor**
  - Simplified channel management logic and improved code readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->