### PR TITLE
fix: Setup home

### DIFF
--- a/Maple2.Model/Game/User/Home.cs
+++ b/Maple2.Model/Game/User/Home.cs
@@ -48,7 +48,7 @@ public class Home : IByteSerializable {
     public int PlotMapId => Outdoor?.MapId ?? 0;
     public int PlotNumber => Outdoor?.Number ?? 0;
     public int ApartmentNumber => Outdoor?.ApartmentNumber ?? 0;
-    public long PlotExpiryTime => Outdoor?.ExpiryTime ?? Indoor.ExpiryTime;
+    public long PlotExpiryTime => Outdoor?.ExpiryTime ?? (string.IsNullOrEmpty(Name) ? 0 : Indoor.ExpiryTime); // If the name is empty, the plot is not setup yet.
     public PlotState State => Outdoor?.State ?? PlotState.Open;
 
     public Home() {

--- a/Maple2.Server.Game/PacketHandlers/HomeHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/HomeHandler.cs
@@ -75,7 +75,8 @@ public class HomeHandler : PacketHandler<GameSession> {
         if (string.IsNullOrEmpty(home.Indoor.Name)) {
             int templateId = packet.ReadInt(); // -1 = none
 
-            if (templateId < -1 && templateId > 2) {
+            if (templateId < -1 || templateId > 2) {
+                Logger.Warning("Invalid template id {templateId} for initializing home for {session.Player.Value.Character.Name}");
                 return;
             }
 

--- a/Maple2.Server.Game/PacketHandlers/HomeHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/HomeHandler.cs
@@ -71,18 +71,19 @@ public class HomeHandler : PacketHandler<GameSession> {
             return;
         }
 
-        int templateId = packet.ReadInt(); // -1 = none
-
-        if (templateId < -1 && templateId > 2) {
-            return;
-        }
-
-        // Template ids in XML are 1-based, but the client uses 0-based
-        templateId++;
-
-        MapMetadataStorage.TryGetExportedUgc(templateId.ToString(), out ExportedUgcMapMetadata? exportedUgcMap);
-
+        // If the home has no name, initialize home
         if (string.IsNullOrEmpty(home.Indoor.Name)) {
+            int templateId = packet.ReadInt(); // -1 = none
+
+            if (templateId < -1 && templateId > 2) {
+                return;
+            }
+
+            // Template ids in XML are 1-based, but the client uses 0-based
+            templateId++;
+
+            MapMetadataStorage.TryGetExportedUgc(templateId.ToString(), out ExportedUgcMapMetadata? exportedUgcMap);
+
             session.Housing.InitNewHome(session.Player.Value.Character.Name, exportedUgcMap);
         }
 


### PR DESCRIPTION
When the home hasn't been setup, **ExpiryTime** should be 0 in the packet.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced home initialization logic to handle scenarios where the home has no name, allowing for default settings based on the player's character name.
- **Bug Fixes**
	- Updated plot expiry time calculation to ensure accurate expiry based on the presence of a home name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->