### PR TITLE
fix: incorrect comparing `DateTimeOffset` with `DateTime`

### DIFF
--- a/Maple2.Database/Storage/Metadata/ServerTableMetadataStorage.cs
+++ b/Maple2.Database/Storage/Metadata/ServerTableMetadataStorage.cs
@@ -47,7 +47,7 @@ public class ServerTableMetadataStorage {
 
     public IEnumerable<GameEvent> GetGameEvents() {
         foreach ((int id, GameEventMetadata gameEvent) in GameEventTable.Entries) {
-            if (gameEvent.EndTime < DateTimeOffset.Now) {
+            if (gameEvent.EndTime < DateTimeOffset.Now.DateTime) {
                 continue;
             }
 


### PR DESCRIPTION
I stumble across this issue today when I try to run "Maple2.Server.World":  
```
An exception of type 'System.ArgumentOutOfRangeException' occurred in System.Private.CoreLib.dll but was not handled in user code: 'The UTC time represented when the offset is applied must be between year 0 and 10,000.'
   at System.DateTimeOffset.ValidateDate(DateTime dateTime, TimeSpan offset)
   at System.DateTimeOffset..ctor(DateTime dateTime)
   at System.DateTimeOffset.op_Implicit(DateTime dateTime)
   at Maple2.Database.Storage.ServerTableMetadataStorage.<GetGameEvents>d__34.MoveNext() in F:\Maple Story 2\Server\Maple2\Maple2.Database\Storage\Metadata\ServerTableMetadataStorage.cs:line 50
   at System.Collections.Generic.List`1..ctor(IEnumerable`1 collection)
   at System.Linq.Enumerable.ToList[TSource](IEnumerable`1 source)
   at Maple2.Server.World.WorldServer.ScheduleGameEvents() in F:\Maple Story 2\Server\Maple2\Maple2.Server.World\WorldServer.cs:line 152
   at Maple2.Server.World.WorldServer..ctor(GameStorage gameStorage, ChannelClientLookup channelClients, ServerTableMetadataStorage serverTableMetadata, GlobalPortalLookup globalPortalLookup) in F:\Maple Story 2\Server\Maple2\Maple2.Server.World\WorldServer.cs:line 35
   at Autofac.Core.Activators.Reflection.BoundConstructor.Instantiate()
```

And find that incorrect comparing `DateTimeOffset` with `DateTime` leads to the issue, so I converted `DateTimeOffset.Now` to `DateTimeOffset.Now.DateTime` to fix the bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the accuracy of game event filtering by refining the logic for comparing event end times.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->