### PR TITLE
name terminal tabs when starting servers with start.bat or dev.bat

### DIFF
--- a/dev.bat
+++ b/dev.bat
@@ -1,3 +1,5 @@
 @echo off
 
-wt -d "Maple2.Server.World" dotnet run ; sp -d "Maple2.Server.Login" dotnet run ; sp -d "Maple2.Server.Web" dotnet run
+wt -d "Maple2.Server.World" --title "World Server" dotnet run ; ^
+sp -d "Maple2.Server.Login" --title "Login Server" dotnet run ; ^
+sp -d "Maple2.Server.Web" --title "Web Server" dotnet run

--- a/start.bat
+++ b/start.bat
@@ -1,4 +1,6 @@
 @echo off
 
-wt -d "Maple2.Server.World" dotnet run ; nt -d "Maple2.Server.Login" dotnet run ; nt -d "Maple2.Server.Web" dotnet run ; nt -d "Maple2.Server.Game" dotnet run
-
+wt -d "Maple2.Server.World" --title "World Server" dotnet run ; ^
+nt -d "Maple2.Server.Login" --title "Login Server" dotnet run ; ^
+nt -d "Maple2.Server.Web" --title "Web Server" dotnet run ; ^
+nt -d "Maple2.Server.Game" --title "Game Server" dotnet run


### PR DESCRIPTION
prevents every tab from being named "dotnet"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved command-line execution for server components with clearer titles for each instance, enhancing user experience and process identification.
- **Style**
	- Reformatted command lines for better readability in execution scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->