### PR TITLE
Fix Find Quest Script State

### DIFF
--- a/Maple2.Server.Game/Manager/NpcScriptManager.cs
+++ b/Maple2.Server.Game/Manager/NpcScriptManager.cs
@@ -239,25 +239,20 @@ public sealed class NpcScriptManager {
         QuestState questState = quest?.State ?? QuestState.None;
 
         int stateId = questState switch {
-            QuestState.None => GetFirstStateScript(scriptMetadata.States.Keys.ToArray(), 100, 200),
-            QuestState.Started => GetFirstStateScript(scriptMetadata.States.Keys.ToArray(), 200, 300),
+            QuestState.None => NpcTalkUtil.GetFirstStateScript(scriptMetadata.States.Keys.ToArray(), 100, 200),
+            QuestState.Started => NpcTalkUtil.GetFirstStateScript(scriptMetadata.States.Keys.ToArray(), 200, 300),
             _ => 0,
         };
 
         if (quest != null && session.Quest.CanStart(quest.Metadata.Require)) {
-            stateId = GetFirstStateScript(scriptMetadata.States.Keys.ToArray(), 200, 300);
+            stateId = NpcTalkUtil.GetFirstStateScript(scriptMetadata.States.Keys.ToArray(), 200, 300);
         }
 
         if (quest != null && quest.Metadata.Basic.CompleteNpc == Npc.Value.Id) {
-            stateId = GetFirstStateScript(scriptMetadata.States.Keys.ToArray(), 300, 400);
+            stateId = NpcTalkUtil.GetFirstStateScript(scriptMetadata.States.Keys.ToArray(), 300, 400);
         }
 
         return scriptMetadata.States.TryGetValue(stateId, out ScriptState? scriptState) ? scriptState : null;
-
-        int GetFirstStateScript(IEnumerable<int> questStates, int lowerBound, int upperBound) {
-            IEnumerable<int> statesInRange = questStates.Where(id => id >= lowerBound && id < upperBound);
-            return statesInRange.Min();
-        }
     }
 
     private NpcTalkButton GetButton() {

--- a/Maple2.Server.Game/Util/NpcTalkUtil.cs
+++ b/Maple2.Server.Game/Util/NpcTalkUtil.cs
@@ -238,10 +238,10 @@ public static class NpcTalkUtil {
         }
 
         return scriptMetadata.States.TryGetValue(stateId, out ScriptState? scriptState) ? scriptState : null;
+    }
 
-        int GetFirstStateScript(IEnumerable<int> questStates, int lowerBound, int upperBound) {
-            IEnumerable<int> statesInRange = questStates.Where(id => id >= lowerBound && id < upperBound);
-            return statesInRange.Min();
-        }
+    public static int GetFirstStateScript(IEnumerable<int> questStates, int lowerBound, int upperBound) {
+        IEnumerable<int> statesInRange = questStates.Where(id => id >= lowerBound && id <= upperBound);
+        return statesInRange.Min();
     }
 }


### PR DESCRIPTION
For edge cases where a quest script does not have a "200" or "2xx" id.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced NPC interaction by centralizing state script retrieval logic, improving modularity and maintainability.
	- Expanded accessibility of the state script retrieval method, allowing for broader use in quest state evaluations.

- **Bug Fixes**
	- Adjusted quest state selection logic to include the upper bound, ensuring more accurate state results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->