### PR TITLE
Fix: FieldEnterPacket

### DIFF
--- a/Maple2.File.Ingest/Maple2.File.Ingest.csproj
+++ b/Maple2.File.Ingest/Maple2.File.Ingest.csproj
@@ -20,7 +20,7 @@
         <PackageReference Include="Crc32.NET" Version="1.2.0" />
         <PackageReference Include="CsvHelper" Version="32.0.2" />
         <PackageReference Include="DotNetZip" Version="1.16.0" />
-        <PackageReference Include="Maple2.File.Parser.Tadeucci" Version="2.1.26" />
+        <PackageReference Include="Maple2.File.Parser.Tadeucci" Version="2.1.27" />
         <PackageReference Include="DotRecast.Core" Version="2024.2.3" />
         <PackageReference Include="DotRecast.Detour" Version="2024.2.3" />
         <PackageReference Include="DotRecast.Recast" Version="2024.2.3" />

--- a/Maple2.Model/Game/FieldInstance.cs
+++ b/Maple2.Model/Game/FieldInstance.cs
@@ -6,11 +6,11 @@ using Maple2.Tools;
 namespace Maple2.Model.Game;
 
 public sealed class FieldInstance : IByteSerializable {
+    public static FieldInstance Default = new(false, InstanceType.none, 0);
+
     public readonly bool BlockChangeChannel;
     public readonly InstanceType InstanceType;
     public readonly int InstanceId;
-
-    public FieldInstance() { }
 
     public FieldInstance(bool blockChangeChannel, InstanceType instanceType, int instanceId) {
         BlockChangeChannel = blockChangeChannel;

--- a/Maple2.Model/Game/FieldInstance.cs
+++ b/Maple2.Model/Game/FieldInstance.cs
@@ -1,17 +1,26 @@
 ﻿using System.Runtime.InteropServices;
 using Maple2.Model.Enum;
+using Maple2.PacketLib.Tools;
+using Maple2.Tools;
 
 namespace Maple2.Model.Game;
 
-[StructLayout(LayoutKind.Sequential, Size = 6)]
-public readonly struct FieldInstance {
+public sealed class FieldInstance : IByteSerializable {
     public readonly bool BlockChangeChannel;
     public readonly InstanceType InstanceType;
     public readonly int InstanceId;
+
+    public FieldInstance() { }
 
     public FieldInstance(bool blockChangeChannel, InstanceType instanceType, int instanceId) {
         BlockChangeChannel = blockChangeChannel;
         InstanceType = instanceType;
         InstanceId = instanceId;
+    }
+
+    public void WriteTo(IByteWriter writer) {
+        writer.WriteBool(BlockChangeChannel);
+        writer.Write<InstanceType>(InstanceType);
+        writer.WriteInt(InstanceId);
     }
 }

--- a/Maple2.Server.Game/Manager/Field/FieldManager.cs
+++ b/Maple2.Server.Game/Manager/Field/FieldManager.cs
@@ -67,7 +67,7 @@ public sealed partial class FieldManager : IDisposable {
     public int MapId => Metadata.Id;
     public readonly long OwnerId;
     public readonly int InstanceId;
-    public FieldInstance FieldInstance = new();
+    public FieldInstance FieldInstance = FieldInstance.Default;
     public readonly AiManager Ai;
     public IFieldRenderer? DebugRenderer { get; private set; }
 

--- a/Maple2.Server.Game/Manager/Field/FieldManager.cs
+++ b/Maple2.Server.Game/Manager/Field/FieldManager.cs
@@ -67,7 +67,7 @@ public sealed partial class FieldManager : IDisposable {
     public int MapId => Metadata.Id;
     public readonly long OwnerId;
     public readonly int InstanceId;
-    public FieldInstance FieldInstance = default;
+    public FieldInstance FieldInstance = new();
     public readonly AiManager Ai;
     public IFieldRenderer? DebugRenderer { get; private set; }
 

--- a/Maple2.Server.Game/Packets/FieldEnterPacket.cs
+++ b/Maple2.Server.Game/Packets/FieldEnterPacket.cs
@@ -7,6 +7,7 @@ using Maple2.Server.Core.Constants;
 using Maple2.Server.Core.Packets;
 using Maple2.Server.Game.Model;
 using Maple2.Server.Game.Session;
+using Maple2.Tools.Extensions;
 
 namespace Maple2.Server.Game.Packets;
 
@@ -15,7 +16,7 @@ public static class FieldEnterPacket {
         var pWriter = Packet.Of(SendOp.RequestFieldEnter);
         pWriter.Write<MigrationError>(MigrationError.ok);
         pWriter.WriteInt(player.Value.Character.MapId);
-        pWriter.Write<FieldInstance>(player.Field.FieldInstance);
+        pWriter.WriteClass<FieldInstance>(player.Field.FieldInstance);
         pWriter.WriteInt();
         pWriter.Write<Vector3>(player.Position);
         pWriter.Write<Vector3>(player.Rotation);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the `Maple2.File.Parser.Tadeucci` package to version 2.1.27, potentially introducing new features and improvements.
	- Enhanced the `FieldInstance` structure to a class with improved serialization capabilities and a new method for writing data.

- **Bug Fixes**
	- Improved initialization of `FieldInstance` in the `FieldManager` to ensure a new instance is always created, enhancing stability.

- **Refactor**
	- Updated serialization logic in the `FieldEnterPacket` class for better handling of `FieldInstance` data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->