### PR TITLE
Fix: Buffs & DotDamage

### DIFF
--- a/Maple2.File.Ingest/Utils/TriggerDefinitionOverride.cs
+++ b/Maple2.File.Ingest/Utils/TriggerDefinitionOverride.cs
@@ -38,8 +38,8 @@ internal class TriggerDefinitionOverride {
             Types = BuildTypeOverride(("spawnId", Int, null), ("duration", Int, null), ("delayTick", Int, null), ("npcID", Int, null)),
         };
         ActionOverride["add_buff"] = new TriggerDefinitionOverride("add_buff") {
-            Names = BuildNameOverride(("arg1", "boxIds"), ("arg2", "skillId"), ("arg3", "level"), ("arg4", "isPlayer"), ("arg5", "isSkillSet")),
-            Types = BuildTypeOverride(("boxIds", IntList, Required), ("skillId", Int, Required), ("level", Int, Required), ("isPlayer", Bool, "True"), ("isSkillSet", Bool, "True")),
+            Names = BuildNameOverride(("arg1", "boxIds"), ("arg2", "skillId"), ("arg3", "level"), ("arg4", "ignorePlayer"), ("arg5", "isSkillSet")),
+            Types = BuildTypeOverride(("boxIds", IntList, Required), ("skillId", Int, Required), ("level", Int, Required), ("ignorePlayer", Bool, "True"), ("isSkillSet", Bool, "True")),
         };
         ActionOverride["add_cinematic_talk"] = new TriggerDefinitionOverride("add_cinematic_talk") {
             Names = BuildNameOverride(("npcID", "npcId"), ("illustID", "illustId"), ("illust", "illustId"), ("delay", "delayTick")),

--- a/Maple2.Server.Game/Manager/ExperienceManager.cs
+++ b/Maple2.Server.Game/Manager/ExperienceManager.cs
@@ -176,6 +176,8 @@ public sealed class ExperienceManager {
             session.ConditionUpdate(ConditionType.level_up, codeLong: (int) session.Player.Value.Character.Job.Code(), targetLong: Level);
             session.ConditionUpdate(ConditionType.level, codeLong: Level);
 
+            session.Stats.Refresh();
+
             session.PlayerInfo.SendUpdate(new PlayerUpdateRequest {
                 AccountId = session.AccountId,
                 CharacterId = session.CharacterId,

--- a/Maple2.Server.Game/Model/Field/Actor/Actor.cs
+++ b/Maple2.Server.Game/Model/Field/Actor/Actor.cs
@@ -171,10 +171,9 @@ public abstract class Actor<T> : IActor<T>, IDisposable {
         foreach (SkillEffectMetadata effect in record.Attack.Skills) {
             if (effect.Condition != null) {
                 foreach (IActor actor in record.Targets) {
-                    IActor caster = GetTarget(effect.Condition.Target, record.Caster, actor);
                     IActor owner = GetTarget(effect.Condition.Target, record.Caster, actor);
-                    if (effect.Condition.Condition.Check(caster, owner, actor)) {
-                        actor.ApplyEffect(caster, owner, effect);
+                    if (effect.Condition.Condition.Check(record.Caster, owner, actor)) {
+                        actor.ApplyEffect(record.Caster, owner, effect);
                     }
                 }
             } else if (effect.Splash != null) {

--- a/Maple2.Server.Game/Model/Field/Actor/IActor.cs
+++ b/Maple2.Server.Game/Model/Field/Actor/IActor.cs
@@ -23,7 +23,6 @@ public interface IActor : IFieldEntity {
 
     public virtual void ApplyEffect(IActor caster, IActor owner, SkillEffectMetadata effect) { }
     public virtual void ApplyDamage(IActor caster, DamageRecord damage, SkillMetadataAttack attack) { }
-    public virtual void AddBuff(IActor caster, IActor owner, int id, short level, bool notifyField = true) { }
 
     public virtual void TargetAttack(SkillRecord record) { }
 

--- a/Maple2.Server.Game/Model/Field/Buff.cs
+++ b/Maple2.Server.Game/Model/Field/Buff.cs
@@ -223,9 +223,9 @@ public class Buff : IUpdatable, IByteSerializable {
 
         AdditionalEffectMetadataDot.DotBuff dotBuff = Metadata.Dot.Buff;
         if (dotBuff.Target == SkillEntity.Target) {
-            Owner.AddBuff(Caster, Owner, dotBuff.Id, dotBuff.Level);
+            Owner.Buffs.AddBuff(Caster, Owner, dotBuff.Id, dotBuff.Level);
         } else {
-            Caster.AddBuff(Caster, Owner, dotBuff.Id, dotBuff.Level);
+            Caster.Buffs.AddBuff(Caster, Owner, dotBuff.Id, dotBuff.Level);
         }
     }
 

--- a/Maple2.Server.Game/Model/Skill/DotDamageRecord.cs
+++ b/Maple2.Server.Game/Model/Skill/DotDamageRecord.cs
@@ -25,6 +25,7 @@ public class DotDamageRecord {
             CanCrit = dotDamage.UseGrade,
             Element = dotDamage.Element,
             AttackType = dotDamage.Type,
+            Rate = dotDamage.Rate,
         };
         Type = DamageType.Normal;
 
@@ -32,7 +33,7 @@ public class DotDamageRecord {
         if (!dotDamage.IsConstDamage) {
             (DamageType type, long amount) = DamageCalculator.CalculateDamage(caster, target, Properties);
             Type = type;
-            hpAmount += (int) (dotDamage.Rate * amount);
+            hpAmount += (int) amount;
             hpAmount += (int) (dotDamage.DamageByTargetMaxHp * Target.Stats.Values[BasicAttribute.Health].Total);
         }
         if (dotDamage.NotKill) {

--- a/Maple2.Server.Game/Scripting/Trigger/TriggerContext.cs
+++ b/Maple2.Server.Game/Scripting/Trigger/TriggerContext.cs
@@ -6,7 +6,7 @@ namespace Maple2.Server.Game.Scripting.Trigger;
 public interface ITriggerContext {
     // Actions
     public void AddBalloonTalk(int spawnId, string msg, int duration, int delayTick, int npcId);
-    public void AddBuff(int[] boxIds, int skillId, int level, bool isPlayer, bool isSkillSet, string feature);
+    public void AddBuff(int[] boxIds, int skillId, int level, bool ignorePlayer, bool isSkillSet, string feature);
     public void AddCinematicTalk(int npcId, string illustId, string msg, int duration, Align align, int delayTick);
     public void AddEffectNif(int spawnId, string nifPath, bool isOutline, float scale, int rotateZ);
     public void AddUserValue(string key, int value);
@@ -110,7 +110,7 @@ public interface ITriggerContext {
     public void PlaySystemSoundInBox(string sound, int[] boxIds);
     public void RandomAdditionalEffect(string target, int boxId, int spawnId, int targetCount, int tick, int waitTick, string targetEffect, int additionalEffectId);
     public void RemoveBalloonTalk(int spawnId);
-    public void RemoveBuff(int boxId, int skillId, bool isPlayer);
+    public void RemoveBuff(int boxId, int skillId, bool ignorePlayer);
     public void RemoveCinematicTalk();
     public void RemoveEffectNif(int spawnId);
     public void ResetCamera(float interpolationTime);

--- a/Maple2.Server.Game/Trigger/TriggerContext.Field.cs
+++ b/Maple2.Server.Game/Trigger/TriggerContext.Field.cs
@@ -350,28 +350,28 @@ public partial class TriggerContext {
         Field.Broadcast(BreakablePacket.Update(updated));
     }
 
-    public void AddBuff(int[] boxIds, int buffId, int level, bool isPlayer, bool isSkillSet, string feature) {
-        DebugLog("[AddBuff] boxIds:{Ids}, buffId:{BuffId}, level:{Level}, isPlayer:{IsPlayer}, isSkillSet:{Arg5}, feature:{Feature}",
-            string.Join(", ", boxIds), buffId, level, isPlayer, isSkillSet, feature);
+    public void AddBuff(int[] boxIds, int buffId, int level, bool ignorePlayer, bool isSkillSet, string feature) {
+        DebugLog("[AddBuff] boxIds:{Ids}, buffId:{BuffId}, level:{Level}, ignorePlayer:{ignorePlayer}, isSkillSet:{Arg5}, feature:{Feature}",
+            string.Join(", ", boxIds), buffId, level, ignorePlayer, isSkillSet, feature);
         if (isSkillSet) {
             logger.Error("[AddBuff] SkillSets not implemented...");
             return;
         }
 
-        if (isPlayer) {
+        if (!ignorePlayer) {
             foreach (IActor player in PlayersInBox(boxIds)) {
-                player.AddBuff(Field.FieldActor, player, buffId, (short) level);
+                player.Buffs.AddBuff(Field.FieldActor, player, buffId, (short) level);
             }
         } else {
             foreach (IActor monster in MonstersInBox(boxIds)) {
-                monster.AddBuff(Field.FieldActor, monster, buffId, (short) level);
+                monster.Buffs.AddBuff(Field.FieldActor, monster, buffId, (short) level);
             }
         }
     }
 
-    public void RemoveBuff(int boxId, int buffId, bool isPlayer) {
-        ErrorLog("[RemoveBuff] boxId:{Id}, buffId:{BuffId}, isPlayer:{IsPlayer}", boxId, buffId, isPlayer);
-        if (isPlayer) {
+    public void RemoveBuff(int boxId, int buffId, bool ignorePlayer) {
+        ErrorLog("[RemoveBuff] boxId:{Id}, buffId:{BuffId}, ignorePlayer:{ignorePlayer}", boxId, buffId, ignorePlayer);
+        if (!ignorePlayer) {
             foreach (IActor player in PlayersInBox(boxId)) {
                 player.Buffs.Remove(buffId);
             }

--- a/Maple2.Server.Game/Trigger/TriggerContext.Npc.cs
+++ b/Maple2.Server.Game/Trigger/TriggerContext.Npc.cs
@@ -246,7 +246,7 @@ public partial class TriggerContext {
 
     private IEnumerable<FieldNpc> NpcsInBox(params int[] boxIds) {
         if (boxIds.Length == 0 || boxIds[0] == 0) {
-            return Field.Mobs.Values;
+            return Field.EnumerateNpcs();
         }
 
         IEnumerable<TriggerBox> boxes = boxIds


### PR DESCRIPTION
Buffs: Now apply correctly from dots & triggers
Dot damage: Now applies the correct caster when calculating the damage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced leveling-up process with automatic player statistics refresh.
  - Improved buff management system, streamlining how buffs are applied to players and NPCs.

- **Bug Fixes**
  - Corrected logic for determining buff application and removal, ensuring more accurate gameplay.

- **Refactor**
  - Simplified logic in skill effect application by directly referencing the caster.
  - Updated methods to focus on NPCs instead of mobs in specific contexts.
  - Standardized parameter names for clarity in buff management methods.

- **Documentation**
  - Updated logging statements to reflect changes in parameter names for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->