### PR TITLE
Query Sellable Tiles

### DIFF
--- a/Maple2.File.Ingest/Mapper/MapDataMapper.cs
+++ b/Maple2.File.Ingest/Mapper/MapDataMapper.cs
@@ -146,15 +146,15 @@ public class MapDataMapper : TypeMapper<MapDataMetadata> {
                     }
 
                     if (entity is IMS2CubeProp cube && cube.CubeSalableGroup != 0) {
-                        entityBounds.Min = -new Vector3(75, 75, 0);
-                        entityBounds.Max = new Vector3(75, 75, 150);
-                        fieldEntity = new FieldSalableTile(
+                        entityBounds.Min = -new Vector3(HALF_BLOCK, HALF_BLOCK, 0);
+                        entityBounds.Max = new Vector3(HALF_BLOCK, HALF_BLOCK, BLOCK_SIZE);
+                        fieldEntity = new FieldSellableTile(
                             Id: entityId,
                             Position: placeable.Position,
                             Rotation: placeable.Rotation,
                             Scale: placeable.Scale,
                             Bounds: entityBounds,
-                            SalableGroup: cube.CubeSalableGroup
+                            SellableGroup: cube.CubeSalableGroup
                         );
 
                         break;

--- a/Maple2.File.Ingest/Mapper/MapDataMapper.cs
+++ b/Maple2.File.Ingest/Mapper/MapDataMapper.cs
@@ -9,12 +9,12 @@ using Maple2.File.Parser.MapXBlock;
 using Maple2.Model.Common;
 using Maple2.Model.Game.Field;
 using Maple2.Model.Metadata;
-using Maple2.Model.Metadata.FieldEntity;
 using Maple2.PacketLib.Tools;
 using Maple2.Tools.Extensions;
 using Maple2.Tools.VectorMath;
 using System.IO.Compression;
 using System.Numerics;
+using Maple2.Model.Metadata.FieldEntity;
 
 namespace Maple2.File.Ingest.Mapper;
 
@@ -141,6 +141,21 @@ public class MapDataMapper : TypeMapper<MapDataMetadata> {
                             Scale: placeable.Scale,
                             Bounds: entityBounds,
                             VibrateIndex: vibrateObjectId++);
+
+                        break;
+                    }
+
+                    if (entity is IMS2CubeProp cube && cube.CubeSalableGroup != 0) {
+                        entityBounds.Min = -new Vector3(75, 75, 0);
+                        entityBounds.Max = new Vector3(75, 75, 150);
+                        fieldEntity = new FieldSalableTile(
+                            Id: entityId,
+                            Position: placeable.Position,
+                            Rotation: placeable.Rotation,
+                            Scale: placeable.Scale,
+                            Bounds: entityBounds,
+                            SalableGroup: cube.CubeSalableGroup
+                        );
 
                         break;
                     }

--- a/Maple2.Model/Game/Field/FieldAccelerationStructure.cs
+++ b/Maple2.Model/Game/Field/FieldAccelerationStructure.cs
@@ -3,7 +3,6 @@ using Maple2.PacketLib.Tools;
 using Maple2.Tools;
 using Maple2.Tools.Extensions;
 using Maple2.Tools.VectorMath;
-using Microsoft.VisualBasic;
 using System.Numerics;
 using System.Runtime.InteropServices;
 using Maple2.Model.Metadata;

--- a/Maple2.Model/Game/Field/FieldAccelerationStructure.cs
+++ b/Maple2.Model/Game/Field/FieldAccelerationStructure.cs
@@ -1,6 +1,4 @@
 ﻿using Maple2.Model.Common;
-using Maple2.Model.Metadata;
-using Maple2.Model.Metadata.FieldEntity;
 using Maple2.PacketLib.Tools;
 using Maple2.Tools;
 using Maple2.Tools.Extensions;
@@ -8,6 +6,8 @@ using Maple2.Tools.VectorMath;
 using Microsoft.VisualBasic;
 using System.Numerics;
 using System.Runtime.InteropServices;
+using Maple2.Model.Metadata;
+using Maple2.Model.Metadata.FieldEntity;
 
 namespace Maple2.Model.Game.Field;
 
@@ -19,21 +19,21 @@ internal enum FieldEntityMembers : byte {
     Rotation = 0x4,
     Scale = 0x8,
     Bounds = 0x10,
-    Llid = 0x20
+    Llid = 0x20,
 }
 
 /*
  * FieldAccelerationStructure is a helper class that specializes in various spatial queries for objects.
  * It's designed to maximize performance for finding objects in a 3D space with desired constraints.
- * 
+ *
  * Internally it uses specialized storage techniques with fast look up times, but knowledge on these
  * techniques isn't necessary for use. The Query functions allow you to find the objects you need without
  * knowing any of the implementation details.
- * 
+ *
  * You can do general queries or queries for specific entity types for all types of queries available.
  * Every entity matching the query constraints will be reported back through a callback, or in a list with
  * Query___List() methods.
- * 
+ *
  * Available query types include:
  * - Cell: Captures all entities in a specific grid cell, or range of cells. Doesn't capture freely floating entities.
  * - Point: Captures all entities intersecting with a specific point.
@@ -54,7 +54,7 @@ internal enum FieldEntityMembers : byte {
  * - Frustum: Captures all entities overlapping with a frustum. Useful for map rendering.
  * - CellsInFrustum: Captures all entities overlapping with a frustum. Useful for map rendering. Doesn't capture freely floating entities.
  * - TreeInFrustum: Captures all entities overlapping with a frustum. Useful for map rendering. Doesn't capture cells.
- * 
+ *
  * Special purpose queries:
  * - Spawns: Captures all mob spawn candidates in a sphere.
  * - Fluids: Captures all fluids within a bounding box.
@@ -178,10 +178,22 @@ public class FieldAccelerationStructure : IByteSerializable, IByteDeserializable
 
     public void QueryFluids(Vector3 min, Vector3 max, Action<FieldFluidEntity> callback) {
         QueryCells(min, max, (entity) => {
-            if (entity is FieldFluidEntity fluid && fluid.IsSurface && !fluid.IsShallow) {
+            if (entity is FieldFluidEntity { IsSurface: true, IsShallow: false } fluid) {
                 callback(fluid);
             }
         });
+    }
+
+    public void QuerySalableTiles(Vector3 min, Vector3 max, Action<FieldSalableTile> callback) {
+        QueryCells(min, max, (entity) => {
+            if (entity is FieldSalableTile tile) {
+                callback(tile);
+            }
+        });
+    }
+
+    public void QuerySalableTilesCenter(Vector3 center, Vector3 size, Action<FieldSalableTile> callback) {
+        QuerySalableTiles(center - 0.5f * size, center + 0.5f * size, callback);
     }
 
     public List<FieldFluidEntity> QueryFluidsList(Vector3 min, Vector3 max) {
@@ -681,7 +693,8 @@ public class FieldAccelerationStructure : IByteSerializable, IByteDeserializable
             FieldFluidEntity => FieldEntityType.Fluid,
             FieldMeshColliderEntity => FieldEntityType.MeshCollider,
             FieldCellEntities => FieldEntityType.Cell,
-            _ => FieldEntityType.Unknown
+            FieldSalableTile => FieldEntityType.SalableTile,
+            _ => throw new InvalidDataException($"Writing unhandled field entity type: {entity.GetType().FullName}"),
         };
 
         FieldEntityMembers memberFlags = FieldEntityMembers.None;
@@ -700,7 +713,7 @@ public class FieldAccelerationStructure : IByteSerializable, IByteDeserializable
                 break;
         }
 
-        writer.Write(type);
+        writer.Write<FieldEntityType>(type);
         writer.Write(memberFlags);
 
         if ((memberFlags & FieldEntityMembers.Id) != 0) {
@@ -752,6 +765,9 @@ public class FieldAccelerationStructure : IByteSerializable, IByteDeserializable
                 foreach (FieldEntity childEntity in cell.Entities) {
                     WriteTo(childEntity, writer);
                 }
+                break;
+            case FieldSalableTile salableTile:
+                writer.Write(salableTile.SalableGroup);
                 break;
             default:
                 throw new InvalidDataException($"Writing unhandled field entity type: {entity.GetType().FullName}");
@@ -928,6 +944,14 @@ public class FieldAccelerationStructure : IByteSerializable, IByteDeserializable
                     Scale: scale,
                     Bounds: bounds,
                     Entities: children);
+            case FieldEntityType.SalableTile:
+                return new FieldSalableTile(
+                    Id: id,
+                    Position: position,
+                    Rotation: rotation,
+                    Scale: scale,
+                    Bounds: bounds,
+                    SalableGroup: reader.Read<int>());
             default:
                 throw new InvalidDataException($"Reading unhandled field entity type: {type}");
         }

--- a/Maple2.Model/Game/Field/FieldAccelerationStructure.cs
+++ b/Maple2.Model/Game/Field/FieldAccelerationStructure.cs
@@ -693,7 +693,7 @@ public class FieldAccelerationStructure : IByteSerializable, IByteDeserializable
             FieldMeshColliderEntity => FieldEntityType.MeshCollider,
             FieldCellEntities => FieldEntityType.Cell,
             FieldSalableTile => FieldEntityType.SalableTile,
-            _ => throw new InvalidDataException($"Writing unhandled field entity type: {entity.GetType().FullName}"),
+            _ => FieldEntityType.Unknown,
         };
 
         FieldEntityMembers memberFlags = FieldEntityMembers.None;
@@ -712,7 +712,7 @@ public class FieldAccelerationStructure : IByteSerializable, IByteDeserializable
                 break;
         }
 
-        writer.Write<FieldEntityType>(type);
+        writer.Write(type);
         writer.Write(memberFlags);
 
         if ((memberFlags & FieldEntityMembers.Id) != 0) {

--- a/Maple2.Model/Game/Field/FieldAccelerationStructure.cs
+++ b/Maple2.Model/Game/Field/FieldAccelerationStructure.cs
@@ -183,16 +183,16 @@ public class FieldAccelerationStructure : IByteSerializable, IByteDeserializable
         });
     }
 
-    public void QuerySalableTiles(Vector3 min, Vector3 max, Action<FieldSalableTile> callback) {
+    public void QuerySellableTiles(Vector3 min, Vector3 max, Action<FieldSellableTile> callback) {
         QueryCells(min, max, (entity) => {
-            if (entity is FieldSalableTile tile) {
+            if (entity is FieldSellableTile tile) {
                 callback(tile);
             }
         });
     }
 
-    public void QuerySalableTilesCenter(Vector3 center, Vector3 size, Action<FieldSalableTile> callback) {
-        QuerySalableTiles(center - 0.5f * size, center + 0.5f * size, callback);
+    public void QuerySellableTilesCenter(Vector3 center, Vector3 size, Action<FieldSellableTile> callback) {
+        QuerySellableTiles(center - 0.5f * size, center + 0.5f * size, callback);
     }
 
     public List<FieldFluidEntity> QueryFluidsList(Vector3 min, Vector3 max) {
@@ -692,7 +692,7 @@ public class FieldAccelerationStructure : IByteSerializable, IByteDeserializable
             FieldFluidEntity => FieldEntityType.Fluid,
             FieldMeshColliderEntity => FieldEntityType.MeshCollider,
             FieldCellEntities => FieldEntityType.Cell,
-            FieldSalableTile => FieldEntityType.SalableTile,
+            FieldSellableTile => FieldEntityType.SellableTile,
             _ => FieldEntityType.Unknown,
         };
 
@@ -765,8 +765,8 @@ public class FieldAccelerationStructure : IByteSerializable, IByteDeserializable
                     WriteTo(childEntity, writer);
                 }
                 break;
-            case FieldSalableTile salableTile:
-                writer.Write(salableTile.SalableGroup);
+            case FieldSellableTile sellableTile:
+                writer.Write(sellableTile.SellableGroup);
                 break;
             default:
                 throw new InvalidDataException($"Writing unhandled field entity type: {entity.GetType().FullName}");
@@ -943,14 +943,14 @@ public class FieldAccelerationStructure : IByteSerializable, IByteDeserializable
                     Scale: scale,
                     Bounds: bounds,
                     Entities: children);
-            case FieldEntityType.SalableTile:
-                return new FieldSalableTile(
+            case FieldEntityType.SellableTile:
+                return new FieldSellableTile(
                     Id: id,
                     Position: position,
                     Rotation: rotation,
                     Scale: scale,
                     Bounds: bounds,
-                    SalableGroup: reader.Read<int>());
+                    SellableGroup: reader.Read<int>());
             default:
                 throw new InvalidDataException($"Reading unhandled field entity type: {type}");
         }

--- a/Maple2.Model/Metadata/FieldEntity/FieldEntity.cs
+++ b/Maple2.Model/Metadata/FieldEntity/FieldEntity.cs
@@ -10,8 +10,8 @@ public enum FieldEntityType : byte {
     BoxCollider, // for cube tiles (IsWhiteBox = false) & arbitrarily sized white boxes
     MeshCollider,
     Fluid,
+    SellableTile,
     Cell, // for cells culled from the grid & demoted to AABB tree
-    SalableTile,
 }
 
 public record FieldEntityId(
@@ -85,11 +85,11 @@ public record FieldCellEntities(
     BoundingBox3 Bounds,
     List<FieldEntity> Entities) : FieldEntity(Id, Position, Rotation, Scale, Bounds);
 
-public record FieldSalableTile(
+public record FieldSellableTile(
     FieldEntityId Id,
     Vector3 Position,
     Vector3 Rotation,
     float Scale,
     BoundingBox3 Bounds,
-    int SalableGroup
+    int SellableGroup
 ) : FieldEntity(Id, Position, Rotation, Scale, Bounds);

--- a/Maple2.Model/Metadata/FieldEntity/FieldEntity.cs
+++ b/Maple2.Model/Metadata/FieldEntity/FieldEntity.cs
@@ -1,5 +1,5 @@
-﻿using Maple2.Tools.VectorMath;
-using System.Numerics;
+﻿using System.Numerics;
+using Maple2.Tools.VectorMath;
 
 namespace Maple2.Model.Metadata.FieldEntity;
 
@@ -10,7 +10,8 @@ public enum FieldEntityType : byte {
     BoxCollider, // for cube tiles (IsWhiteBox = false) & arbitrarily sized white boxes
     MeshCollider,
     Fluid,
-    Cell // for cells culled from the grid & demoted to AABB tree
+    Cell, // for cells culled from the grid & demoted to AABB tree
+    SalableTile,
 }
 
 public record FieldEntityId(
@@ -83,3 +84,12 @@ public record FieldCellEntities(
     float Scale,
     BoundingBox3 Bounds,
     List<FieldEntity> Entities) : FieldEntity(Id, Position, Rotation, Scale, Bounds);
+
+public record FieldSalableTile(
+    FieldEntityId Id,
+    Vector3 Position,
+    Vector3 Rotation,
+    float Scale,
+    BoundingBox3 Bounds,
+    int SalableGroup
+) : FieldEntity(Id, Position, Rotation, Scale, Bounds);

--- a/Maple2.Server.Game/Commands/DebugCommand.cs
+++ b/Maple2.Server.Game/Commands/DebugCommand.cs
@@ -150,7 +150,7 @@ public class DebugCommand : Command {
             AddCommand(new DebugQuerySpawnCommand(session, mapDataStorage));
             AddCommand(new DebugQueryFluidCommand(session, mapDataStorage));
             AddCommand(new DebugQueryVibrateCommand(session, mapDataStorage));
-            AddCommand(new DebugQuerySalableTileCommand(session, mapDataStorage));
+            AddCommand(new DebugQuerySellableTileCommand(session, mapDataStorage));
         }
 
         private class DebugQuerySpawnCommand : Command {
@@ -276,11 +276,11 @@ public class DebugCommand : Command {
             }
         }
 
-        private class DebugQuerySalableTileCommand : Command {
+        private class DebugQuerySellableTileCommand : Command {
             private readonly GameSession session;
             private readonly MapDataStorage mapDataStorage;
 
-            public DebugQuerySalableTileCommand(GameSession session, MapDataStorage mapDataStorage) : base("salable", "Searches for nearby salable tiles.") {
+            public DebugQuerySellableTileCommand(GameSession session, MapDataStorage mapDataStorage) : base("sellable", "Searches for nearby sellable tiles.") {
                 this.session = session;
                 this.mapDataStorage = mapDataStorage;
 
@@ -309,12 +309,12 @@ public class DebugCommand : Command {
 
                 ctx.Console.Out.WriteLine($"Player at {center.X} {center.Y} {center.Z} in cell {cell.X} {cell.Y} {cell.Z}");
 
-                mapData.QuerySalableTilesCenter(session.Player.Position, 2 * new Vector3(x, y, z), (salableTile) => {
-                    Vector3 position = salableTile.Position;
+                mapData.QuerySellableTilesCenter(session.Player.Position, 2 * new Vector3(x, y, z), (sellableTile) => {
+                    Vector3 position = sellableTile.Position;
                     Vector3S toCell = FieldAccelerationStructure.PointToCell(position);
 
 
-                    ctx.Console.Out.WriteLine($"SalableGroupId {salableTile.SalableGroup} found at {position.X} {position.Y} {position.Z} in cell {toCell.X} {toCell.Y} {toCell.Z}");
+                    ctx.Console.Out.WriteLine($"SellableGroupId {sellableTile.SellableGroup} found at {position.X} {position.Y} {position.Z} in cell {toCell.X} {toCell.Y} {toCell.Z}");
                 });
             }
         }

--- a/Maple2.Server.Game/Model/Field/Entity/FieldMobSpawn.cs
+++ b/Maple2.Server.Game/Model/Field/Entity/FieldMobSpawn.cs
@@ -2,6 +2,7 @@
 using Maple2.Model.Game;
 using Maple2.Model.Game.Field;
 using Maple2.Model.Metadata;
+using Maple2.Model.Metadata.FieldEntity;
 using Maple2.Server.Game.Manager.Field;
 using Maple2.Server.Game.Packets;
 using Maple2.Tools;

--- a/Maple2.Server.Game/Model/Field/Entity/FieldMobSpawn.cs
+++ b/Maple2.Server.Game/Model/Field/Entity/FieldMobSpawn.cs
@@ -2,7 +2,6 @@
 using Maple2.Model.Game;
 using Maple2.Model.Game.Field;
 using Maple2.Model.Metadata;
-using Maple2.Model.Metadata.FieldEntity;
 using Maple2.Server.Game.Manager.Field;
 using Maple2.Server.Game.Packets;
 using Maple2.Tools;


### PR DESCRIPTION
This pull request introduces new functionality for handling salable tiles in the game field and includes several code improvements and refactorings. The most important changes are the addition of a new `FieldSalableTile` entity, updates to the `FieldAccelerationStructure` class to support this new entity, and the addition of a debug command for querying salable tiles.

### New Functionality:

* Added `FieldSalableTile` entity to represent salable tiles in the game field. (`Maple2.Model/Metadata/FieldEntity/FieldEntity.cs`)
* Updated `FieldAccelerationStructure` class to handle `FieldSalableTile` entities, including methods to query and write these entities. (`Maple2.Model/Game/Field/FieldAccelerationStructure.cs`) [[1]](diffhunk://#diff-9d2d34746c8a70ef5ce249df2367f1ad1a23c727455b5412fb590e97c6b8654bL181-R197) [[2]](diffhunk://#diff-9d2d34746c8a70ef5ce249df2367f1ad1a23c727455b5412fb590e97c6b8654bR768-R770) [[3]](diffhunk://#diff-9d2d34746c8a70ef5ce249df2367f1ad1a23c727455b5412fb590e97c6b8654bR946-R953)

### Code Improvements:

* Added a new debug command `DebugQuerySalableTileCommand` to query salable tiles in the game field. (`Maple2.Server.Game/Commands/DebugCommand.cs`) [[1]](diffhunk://#diff-ab769d130c5d9bcc02913aa584ffbe68399e87d54fea894c92d8becc6f27f830R153) [[2]](diffhunk://#diff-ab769d130c5d9bcc02913aa584ffbe68399e87d54fea894c92d8becc6f27f830R278-R320)

### Refactorings:

* Updated `FieldEntityType` enum to include `SalableTile`. (`Maple2.Model/Metadata/FieldEntity/FieldEntity.cs`)
* Refactored entity parsing logic to include `FieldSalableTile` in `ParseMapEntities` method. (`Maple2.File.Ingest/Mapper/MapDataMapper.cs`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced support for `FieldSellableTile` entities, enhancing entity parsing and querying capabilities.
	- Added new methods for querying sellable tiles within specified bounds and centers.
	- Implemented a new command for debugging sellable tiles, allowing developers to query and display tile information in the game world.

- **Bug Fixes**
	- Improved consistency in formatting for enum declarations.

- **Documentation**
	- Refined documentation comments for clarity without altering content meaning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->