### PR TITLE
Fix newest item order

### DIFF
--- a/Maple2.Database/Storage/Game/GameStorage.Market.cs
+++ b/Maple2.Database/Storage/Game/GameStorage.Market.cs
@@ -184,7 +184,7 @@ public partial class GameStorage {
         public ICollection<UgcMarketItem> GetUgcMarketNewItems() {
             ICollection<UgcMarketItem> items = Context.UgcMarketItem
                 .Where(item => item.ListingEndTime > DateTime.Now)
-                .OrderBy(item => item.CreationTime)
+                .OrderByDescending(item => item.CreationTime)
                 .Take(6)
                 .AsEnumerable()
                 .Select(ToMarketEntry)

--- a/Maple2.Server.Game/PacketHandlers/MeretMarketHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/MeretMarketHandler.cs
@@ -154,6 +154,7 @@ public class MeretMarketHandler : PacketHandler<GameSession> {
             Status = UgcMarketListingStatus.Active,
             PromotionEndTime = promote ? DateTime.Now.AddHours(Constant.UGCShopAdHour).ToEpochSeconds() : 0,
             ListingEndTime = DateTime.Now.AddDays(Constant.UGCShopSaleDay).ToEpochSeconds(),
+            CreationTime = DateTime.Now.ToEpochSeconds(),
             Price = Math.Clamp(price, Constant.UGCShopSellMinPrice, Constant.UGCShopSellMaxPrice),
             TabId = tabId,
         };


### PR DESCRIPTION
Fixes issue #263 

Findings:
Re-listing an item will not change the how the item is ordered. The ordering is based on the CreationTime which is set when the item is added to the UGC Market. Unsure how it worked originally, but if re-listing resets the ordering then perhaps a new column `ListingTime` is tracked and updated on adding and relisting?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Market items are now displayed in descending order by creation time, ensuring the newest items appear first.
	- Added a `CreationTime` property to market items to track when they are listed.
	- Enhanced filtering options for market items based on gender and job criteria.

- **Bug Fixes**
	- Improved robustness in item retrieval by checking for null values before processing.

- **Chores**
	- Updated resource management practices in market item handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->