### PR TITLE
Open Multiple ItemBox Fix

### DIFF
--- a/Maple2.Server.Game/PacketHandlers/ItemBoxHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/ItemBoxHandler.cs
@@ -17,7 +17,7 @@ public class ItemBoxHandler : PacketHandler<GameSession> {
         short unk = packet.ReadShort();
         int count = packet.ReadInt();
 
-        Item ? item = session.Item.Inventory.Find(itemId).FirstOrDefault();
+        Item? item = session.Item.Inventory.Find(itemId).FirstOrDefault();
         if (item == null) {
             return;
         }

--- a/Maple2.Server.Game/PacketHandlers/ItemBoxHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/ItemBoxHandler.cs
@@ -1,4 +1,5 @@
-﻿using Maple2.Model.Error;
+﻿using Maple2.Model.Enum;
+using Maple2.Model.Error;
 using Maple2.Model.Game;
 using Maple2.PacketLib.Tools;
 using Maple2.Server.Core.Constants;
@@ -15,12 +16,13 @@ public class ItemBoxHandler : PacketHandler<GameSession> {
         int itemId = packet.ReadInt();
         short unk = packet.ReadShort();
         int count = packet.ReadInt();
-        if (!int.TryParse(packet.ReadUnicodeString(), out int index)) {
+
+        Item ? item = session.Item.Inventory.Find(itemId).FirstOrDefault();
+        if (item == null) {
             return;
         }
 
-        Item? item = session.Item.Inventory.Find(itemId).FirstOrDefault();
-        if (item == null) {
+        if (!int.TryParse(packet.ReadUnicodeString(), out int index) && item.Metadata?.Function?.Type == ItemFunction.SelectItemBox) {
             return;
         }
 


### PR DESCRIPTION
Allows opening multiple item boxes at once of types other than SelectItemBox.  Item boxes other than SelectItemBox do not send an index which previously caused Handle to fail to get an index and return unnecessarily.  We now only care about missing indices when the item box is a SelectItemBox.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of item retrieval from inventory, ensuring that checks for item existence occur before processing further.
	- Enhanced control flow to prevent errors related to parsing when items are not found.

- **Chores**
	- Updated import statements for better organization and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->