### PR TITLE
Don't dispose field if it has ad balloons active

### DIFF
--- a/Maple2.Server.Game/Manager/Field/FieldManager.Factory.cs
+++ b/Maple2.Server.Game/Manager/Field/FieldManager.Factory.cs
@@ -122,19 +122,12 @@ public partial class FieldManager {
                         continue;
                     }
 
-                    bool hasAdBalloons = false;
-                    foreach (FieldInteract fieldInteract in fieldManager.fieldAdBalloons.Values) {
-                        if (fieldInteract.Object is not InteractBillBoardObject billboard || DateTime.Now.ToEpochSeconds() >= billboard.ExpirationTime) continue;
-                        hasAdBalloons = true;
-                        break;
-                    }
-
-                    if (hasAdBalloons) {
+                    if (fieldManager.fieldAdBalloons.Values
+                        .Any(fieldInteract => fieldInteract.Object is InteractBillBoardObject billboard && DateTime.Now.ToEpochSeconds() < billboard.ExpirationTime)) {
                         logger.Verbose("Field {MapId} {InstanceId} has ad balloons", fieldManager.MapId, fieldManager.InstanceId);
                         fieldManager.fieldEmptySince = null;
                         continue;
                     }
-
                     Model.RoomTimer? roomTimer = fieldManager.RoomTimer;
                     if (roomTimer is null) {
                         if (fieldManager.fieldEmptySince is null) {

--- a/Maple2.Server.Game/Manager/Field/FieldManager.Factory.cs
+++ b/Maple2.Server.Game/Manager/Field/FieldManager.Factory.cs
@@ -1,9 +1,12 @@
 ﻿using System.Collections.Concurrent;
 using System.Diagnostics;
 using Autofac;
+using Maple2.Database.Extensions;
 using Maple2.Database.Storage;
 using Maple2.Database.Storage.Metadata;
+using Maple2.Model.Game;
 using Maple2.Model.Metadata;
+using Maple2.Server.Game.Model;
 using Serilog;
 
 namespace Maple2.Server.Game.Manager.Field;
@@ -115,6 +118,19 @@ public partial class FieldManager {
                 foreach (FieldManager fieldManager in fields.AllFields) {
                     if (!fieldManager.Players.IsEmpty) {
                         logger.Verbose("Field {MapId} {InstanceId} has players", fieldManager.MapId, fieldManager.InstanceId);
+                        fieldManager.fieldEmptySince = null;
+                        continue;
+                    }
+
+                    bool hasAdBalloons = false;
+                    foreach (FieldInteract fieldInteract in fieldManager.fieldAdBalloons.Values) {
+                        if (fieldInteract.Object is not InteractBillBoardObject billboard || DateTime.Now.ToEpochSeconds() >= billboard.ExpirationTime) continue;
+                        hasAdBalloons = true;
+                        break;
+                    }
+
+                    if (hasAdBalloons) {
+                        logger.Verbose("Field {MapId} {InstanceId} has ad balloons", fieldManager.MapId, fieldManager.InstanceId);
                         fieldManager.fieldEmptySince = null;
                         continue;
                     }

--- a/Maple2.Server.Game/Manager/Field/FieldManager.State.cs
+++ b/Maple2.Server.Game/Manager/Field/FieldManager.State.cs
@@ -589,12 +589,17 @@ public partial class FieldManager {
         return true;
     }
 
-    public bool RemoveInteract(string entityId) {
-        if (fieldInteracts.TryRemove(entityId, out FieldInteract? fieldInteract)) {
-            return false;
+    public bool RemoveInteract(IInteractObject interactObject) {
+        switch (interactObject) {
+            case InteractBillBoardObject billboard:
+                fieldAdBalloons.TryRemove(billboard.EntityId, out _);
+                break;
+            default:
+                fieldInteracts.TryRemove(interactObject.EntityId, out _);
+                break;
         }
 
-        Broadcast(InteractObjectPacket.Remove(entityId));
+        Broadcast(InteractObjectPacket.Remove(interactObject.EntityId));
         return true;
     }
 

--- a/Maple2.Server.Game/Model/Field/Entity/FieldInteract.cs
+++ b/Maple2.Server.Game/Model/Field/Entity/FieldInteract.cs
@@ -64,7 +64,7 @@ public class FieldInteract : FieldEntity<InteractObjectMetadata> {
         // TODO: Include treasure chests
         if (Object is InteractBillBoardObject billboard && DateTime.Now.ToEpochSeconds() > billboard.ExpirationTime) {
             SetState(InteractState.Hidden);
-            Field.RemoveInteract(EntityId);
+            Field.RemoveInteract(Object);
             return;
         }
 


### PR DESCRIPTION
- Resolves #288 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced field state management to ensure active advertisement balloons prevent premature field disposal.
	- Updated the interact removal process to work directly with interactable objects, ensuring more reliable handling of different interaction types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->