### PR TITLE
Shop Purchase & Field Instruments Fix

### DIFF
--- a/Maple2.Server.Game/Manager/ShopManager.cs
+++ b/Maple2.Server.Game/Manager/ShopManager.cs
@@ -436,7 +436,7 @@ public sealed class ShopManager {
             }
         }
 
-        if (quantity > shopItem.StockCount - shopItem.StockPurchased) {
+        if (shopItem.StockCount != 0 && quantity > shopItem.StockCount - shopItem.StockPurchased) {
             session.Send(ShopPacket.Error(ShopError.s_err_lack_shopitem));
             return;
         }

--- a/Maple2.Server.Game/Model/Field/Entity/FieldInstrument.cs
+++ b/Maple2.Server.Game/Model/Field/Entity/FieldInstrument.cs
@@ -1,4 +1,5 @@
-﻿using Maple2.Model.Metadata;
+﻿using Maple2.Model.Game;
+using Maple2.Model.Metadata;
 using Maple2.Server.Game.Manager.Field;
 
 namespace Maple2.Server.Game.Model;
@@ -8,5 +9,6 @@ public class FieldInstrument(FieldManager field, int objectId, InstrumentMetadat
     public bool Improvising { get; set; }
     public long StartTick { get; set; }
     public bool Ensemble { get; set; }
+    public Item? Score { get; set; }
 
 }

--- a/Maple2.Server.Game/PacketHandlers/InstrumentHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/InstrumentHandler.cs
@@ -138,6 +138,7 @@ public class InstrumentHandler : PacketHandler<GameSession> {
         if (!TryUseInstrument(session, itemUid, Environment.TickCount64, false, out session.Instrument)) {
             return;
         }
+        session.Instrument.Score = score;
 
         score.RemainUses--;
         session.Field.Broadcast(InstrumentPacket.StartScore(session.Instrument, score));
@@ -168,7 +169,7 @@ public class InstrumentHandler : PacketHandler<GameSession> {
         // Modifier is the number of 500ms ticks that have passed.
         session.Exp.AddExp(expType, (totalTickTime - 500) / 500);
 
-        session.Field.Broadcast(InstrumentPacket.StopScore(session.Instrument));
+        session.Field.RemoveInstrument(session.Instrument.ObjectId);
         session.Instrument = null;
     }
 
@@ -333,7 +334,7 @@ public class InstrumentHandler : PacketHandler<GameSession> {
             return false;
         }
 
-        fieldInstrument = session.Field!.SpawnInstrument(session.Player, metadata);
+        fieldInstrument = session.Field.SpawnInstrument(session.Player, metadata);
         fieldInstrument.StartTick = startTick;
         fieldInstrument.Ensemble = ensemble;
         return true;

--- a/Maple2.Server.World/Migrations/20250207213214_HomeDecoration.cs
+++ b/Maple2.Server.World/Migrations/20250207213214_HomeDecoration.cs
@@ -32,6 +32,7 @@ namespace Maple2.Server.World.Migrations {
                 name: "InteriorRewardsClaimed",
                 table: "home",
                 type: "json",
+                defaultValue: "[]",
                 nullable: false)
                 .Annotation("MySql:CharSet", "utf8mb4");
         }


### PR DESCRIPTION
- Fixes unable to buy shop items if its an unlimited supply (i.e no stock count)
- Fixes field instruments loading when a player enters a map that a score is in progress
- Migration fix on Home Rewards Claimed
- Fixes #283 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced instrument state management to ensure new players receive current score updates and instruments are removed promptly when inactive.
  - Added support for optional instrument score tracking for more flexible in-game performance.

- **Bug Fixes**
  - Improved purchase validation to prevent transactions when items are unavailable due to zero stock.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->