### PR TITLE
Field Spawn Groups

### DIFF
--- a/Maple2.Database/Storage/Metadata/MapEntityStorage.cs
+++ b/Maple2.Database/Storage/Metadata/MapEntityStorage.cs
@@ -38,6 +38,7 @@ public class MapEntityStorage(MetadataContext context) : MetadataStorage<string,
             var playerSpawns = new Dictionary<int, SpawnPointPC>();
             var npcSpawns = new List<SpawnPointNPC>();
             var regionSpawns = new Dictionary<int, Ms2RegionSpawn>();
+            var boxRegionSpawns = new Dictionary<int, Ms2RegionBoxSpawn>();
             var regionSkills = new List<Ms2RegionSkill>();
             var eventNpcSpawns = new Dictionary<int, EventSpawnPointNPC>();
             var eventItemSpawns = new Dictionary<int, EventSpawnPointItem>();
@@ -67,6 +68,9 @@ public class MapEntityStorage(MetadataContext context) : MetadataStorage<string,
                         break;
                     case Portal portal:
                         portals[portal.Id] = portal;
+                        break;
+                    case Ms2RegionBoxSpawn boxRegionSpawn:
+                        boxRegionSpawns[boxRegionSpawn.Id] = boxRegionSpawn;
                         break;
                     case Ms2RegionSpawn regionSpawn:
                         regionSpawns[regionSpawn.Id] = regionSpawn;
@@ -127,6 +131,7 @@ public class MapEntityStorage(MetadataContext context) : MetadataStorage<string,
                 EventNpcSpawns = eventNpcSpawns,
                 EventItemSpawns = eventItemSpawns,
                 RegionSpawns = regionSpawns,
+                BoxRegionSpawns = boxRegionSpawns,
                 RegionSkills = regionSkills,
                 Taxi = taxi,
                 BoundingBox = bounding ?? LargeBoundingBox,

--- a/Maple2.Database/Storage/Metadata/ServerTableMetadataStorage.cs
+++ b/Maple2.Database/Storage/Metadata/ServerTableMetadataStorage.cs
@@ -25,6 +25,7 @@ public class ServerTableMetadataStorage {
     private readonly Lazy<BeautyShopTable> beautyShopTable;
     private readonly Lazy<MeretMarketTable> meretMarketTable;
     private readonly Lazy<FishTable> fishTable;
+    private readonly Lazy<CombineSpawnTable> combineSpawnTable;
 
     public InstanceFieldTable InstanceFieldTable => instanceFieldTable.Value;
     public ScriptConditionTable ScriptConditionTable => scriptConditionTable.Value;
@@ -44,6 +45,7 @@ public class ServerTableMetadataStorage {
     public BeautyShopTable BeautyShopTable => beautyShopTable.Value;
     public MeretMarketTable MeretMarketTable => meretMarketTable.Value;
     public FishTable FishTable => fishTable.Value;
+    public CombineSpawnTable CombineSpawnTable => combineSpawnTable.Value;
 
     public ServerTableMetadataStorage(MetadataContext context) {
         instanceFieldTable = Retrieve<InstanceFieldTable>(context, "instancefield.xml");
@@ -64,6 +66,7 @@ public class ServerTableMetadataStorage {
         beautyShopTable = Retrieve<BeautyShopTable>(context, "shop_beauty.xml");
         meretMarketTable = Retrieve<MeretMarketTable>(context, "shop_merat_custom.xml");
         fishTable = Retrieve<FishTable>(context, "fish*.xml");
+        combineSpawnTable = Retrieve<CombineSpawnTable>(context, "combineSpawn*.xml");
     }
 
     public IEnumerable<GameEvent> GetGameEvents() {

--- a/Maple2.File.Ingest/Mapper/ItemMapper.cs
+++ b/Maple2.File.Ingest/Mapper/ItemMapper.cs
@@ -215,8 +215,9 @@ public class ItemMapper : TypeMapper<ItemMetadata> {
                 ),
                 Skill: skill,
                 Function: function,
-                AdditionalEffects: data.AdditionalEffect.id.Zip(data.AdditionalEffect.level,
-                    (skillId, level) => new ItemMetadataAdditionalEffect(skillId, level)).ToArray(),
+                AdditionalEffects: data.AdditionalEffect.id
+                .Zip(data.AdditionalEffect.level, (skillId, level) => new ItemMetadataAdditionalEffect(skillId, level, data.AdditionalEffect.dropEffect))
+                .ToArray(),
                 Option: option,
                 Music: music,
                 Housing: housing,

--- a/Maple2.File.Ingest/Mapper/MapEntityMapper.cs
+++ b/Maple2.File.Ingest/Mapper/MapEntityMapper.cs
@@ -119,6 +119,11 @@ public class MapEntityMapper : TypeMapper<MapEntity> {
                             continue;
                     }
                     continue;
+                case IMS2RegionBoxSpawn boxSpawn:
+                    yield return new MapEntity(xblock, new Guid(entity.EntityId), entity.EntityName) {
+                        Block = new Ms2RegionBoxSpawn(boxSpawn.SpawnPointID, (int) boxSpawn.SpawnTypeID, boxSpawn.Scale, boxSpawn.Position, boxSpawn.Rotation)
+                    };
+                    continue;
                 case IMS2RegionSpawnBase spawn:
                     yield return new MapEntity(xblock, new Guid(entity.EntityId), entity.EntityName) {
                         Block = new Ms2RegionSpawn(spawn.SpawnPointID, spawn.UseRotAsSpawnDir, spawn.Position, spawn.Rotation)

--- a/Maple2.Model/Enum/CombineSpawnGroupType.cs
+++ b/Maple2.Model/Enum/CombineSpawnGroupType.cs
@@ -1,0 +1,9 @@
+﻿using System.ComponentModel;
+
+namespace Maple2.Model.Enum;
+
+public enum CombineSpawnGroupType {
+    none,
+    npc,
+    interactObject
+}

--- a/Maple2.Model/Enum/Interact.cs
+++ b/Maple2.Model/Enum/Interact.cs
@@ -65,4 +65,9 @@ public enum InteractCubeControlType {
     OpenWeb,
     Sensor,
     FunctionUI,
+    Notice,
+    InstallNPC,
+    Portal,
+    SpawnPoint,
+    PVP
 }

--- a/Maple2.Model/Game/IFieldProperty.cs
+++ b/Maple2.Model/Game/IFieldProperty.cs
@@ -74,20 +74,18 @@ public class FieldPropertyUserTagSymbol : IFieldProperty {
 public class FieldPropertySightRange : IFieldProperty {
     public FieldProperty Type => FieldProperty.SightRange;
 
-    public float Range { get; init; }
-    public float Fade1 { get; init; }
-    public float Fade2 { get; init; }
-    public float Fade3 { get; init; }
-    public bool Unknown { get; init; }
-    public byte Opacity { get; init; }
-    public bool Opaque { get; init; } = true;
+    public float Range { get; set; } = 450;
+    public float[] Fades { get; init; } = new float[3];
+    public bool Unknown { get; set; }
+    public byte Opacity { get; set; }
+    public bool Opaque { get; set; } = false;
 
     public void WriteTo(IByteWriter writer) {
         writer.Write<FieldProperty>(Type);
         writer.WriteFloat(Range);
-        writer.WriteFloat(Fade1);
-        writer.WriteFloat(Fade2);
-        writer.WriteFloat(Fade3);
+        foreach (float fade in Fades) {
+            writer.WriteFloat(fade);
+        }
         writer.WriteBool(Unknown);
         writer.WriteByte(Opacity);
         writer.WriteBool(Opaque);

--- a/Maple2.Model/Metadata/ItemMetadata.cs
+++ b/Maple2.Model/Metadata/ItemMetadata.cs
@@ -85,7 +85,8 @@ public record ItemMetadataFunction(
 
 public record ItemMetadataAdditionalEffect(
     int Id,
-    short Level);
+    short Level,
+    bool PickUpEffect);
 
 public record ItemMetadataOption(
     int StaticId,

--- a/Maple2.Model/Metadata/MapEntity/MapEntity.cs
+++ b/Maple2.Model/Metadata/MapEntity/MapEntity.cs
@@ -57,4 +57,5 @@ public class MapEntity {
 [JsonDerivedType(typeof(TriggerModel), 1436346081)]
 [JsonDerivedType(typeof(Ms2Bounding), 1539875768)]
 [JsonDerivedType(typeof(MS2PatrolData), 250722994)]
+[JsonDerivedType(typeof(Ms2RegionBoxSpawn), 465193598)]
 public abstract record MapBlock;

--- a/Maple2.Model/Metadata/MapEntity/Ms2RegionBoxSpawn.cs
+++ b/Maple2.Model/Metadata/MapEntity/Ms2RegionBoxSpawn.cs
@@ -1,0 +1,11 @@
+﻿using System.Numerics;
+
+namespace Maple2.Model.Metadata;
+
+public record Ms2RegionBoxSpawn(
+    int Id,
+    int SpawnTypeId,
+    float Scale,
+    Vector3 Position,
+    Vector3 Rotation
+) : MapBlock;

--- a/Maple2.Model/Metadata/MapEntityMetadata.cs
+++ b/Maple2.Model/Metadata/MapEntityMetadata.cs
@@ -16,6 +16,7 @@ public class MapEntityMetadata {
     public required IReadOnlyDictionary<int, SpawnPointPC> PlayerSpawns { get; init; }
     public required IReadOnlyList<SpawnPointNPC> NpcSpawns { get; init; }
     public required IReadOnlyDictionary<int, Ms2RegionSpawn> RegionSpawns { get; init; }
+    public required IReadOnlyDictionary<int, Ms2RegionBoxSpawn> BoxRegionSpawns { get; init; }
     public required IReadOnlyList<Ms2RegionSkill> RegionSkills { get; init; }
     public required IReadOnlyDictionary<int, EventSpawnPointNPC> EventNpcSpawns { get; init; }
     public required IReadOnlyDictionary<int, EventSpawnPointItem> EventItemSpawns { get; init; }

--- a/Maple2.Model/Metadata/ServerTable/CombineSpawnTable.cs
+++ b/Maple2.Model/Metadata/ServerTable/CombineSpawnTable.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using Maple2.Model.Enum;
+
+namespace Maple2.Model.Metadata;
+
+public record CombineSpawnTable(IReadOnlyDictionary<int, Dictionary<int, SpawnGroupMetadata>> Groups, // Key 1: MapId, Key 2: groupId
+                              IReadOnlyDictionary<int, Dictionary<int, SpawnNpcMetadata>> Npcs,
+                              IReadOnlyDictionary<int, Dictionary<int, SpawnInteractObjectMetadata>> InteractObjects) : ServerTable; // Key 1: groupId, Key 2: combineId
+
+public record SpawnGroupMetadata(
+    int GroupId,
+    CombineSpawnGroupType Type,
+    int TotalCount,
+    int ResetTick,
+    int MapId);
+
+public record SpawnNpcMetadata(
+    int CombineId,
+    int GroupId,
+    int Weight,
+    int SpawnId);
+
+public record SpawnInteractObjectMetadata(
+    int CombineId,
+    int GroupId,
+    int Weight,
+    int RegionSpawnId,
+    int InteractId,
+    string Model,
+    string Asset,
+    string Normal,
+    string Reactable,
+    float Scale,
+    bool KeepAnimate);

--- a/Maple2.Model/Metadata/ServerTableMetadata.cs
+++ b/Maple2.Model/Metadata/ServerTableMetadata.cs
@@ -43,4 +43,5 @@ public class ServerTableMetadata {
 [JsonDerivedType(typeof(BeautyShopTable), typeDiscriminator: "beautyShop")]
 [JsonDerivedType(typeof(MeretMarketTable), typeDiscriminator: "meretMarket")]
 [JsonDerivedType(typeof(FishTable), typeDiscriminator: "fish")]
+[JsonDerivedType(typeof(CombineSpawnTable), typeDiscriminator: "combineSpawn")]
 public abstract record ServerTable;

--- a/Maple2.Server.DebugGame/Maple2.Server.DebugGame.csproj
+++ b/Maple2.Server.DebugGame/Maple2.Server.DebugGame.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Silk.NET.Direct3D.Compilers" Version="2.21.0" />
     <PackageReference Include="Silk.NET.Direct3D11" Version="2.21.0" />
     <PackageReference Include="Silk.NET.DXGI" Version="2.21.0" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.State.cs
+++ b/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.State.cs
@@ -400,6 +400,7 @@ public partial class FieldManager {
                 Position = boxSpawn.Position,
                 RotationAnglesDegrees = boxSpawn.Rotation,
             },
+            SpawnId = boxSpawn.Id,
         };
         fieldChests[interactObject.EntityId] = fieldInteract;
         Broadcast(InteractObjectPacket.Add(fieldInteract.Object));
@@ -665,6 +666,7 @@ public partial class FieldManager {
                     break;
                 default:
                     fieldInteracts.TryRemove(interactObject.EntityId, out _);
+                    fieldAdBalloons.TryRemove(interactObject.EntityId, out _);
                     break;
             }
 
@@ -799,6 +801,10 @@ public partial class FieldManager {
             added.Session.Send(FieldPropertyPacket.Background(background));
         }
         added.Session.Send(FieldPropertyPacket.Load(fieldProperties.Values));
+
+        foreach (TickTimer timer in Timers.Values.Where(timer => timer.Display)) {
+            Broadcast(TriggerPacket.TimerDialog(timer));
+        }
     }
     #endregion Events
 }

--- a/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.State.cs
+++ b/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.State.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using DotRecast.Detour.Crowd;
+using Maple2.Model.Common;
 using Maple2.Model.Enum;
 using Maple2.Model.Game;
 using Maple2.Model.Metadata;
@@ -14,6 +15,7 @@ using Maple2.Server.Game.Util;
 using Maple2.Tools;
 using Maple2.Tools.Collision;
 using Maple2.Tools.Extensions;
+using Maple2.Tools.VectorMath;
 using Serilog;
 
 namespace Maple2.Server.Game.Manager.Field;
@@ -31,9 +33,12 @@ public partial class FieldManager {
     private readonly ConcurrentDictionary<string, FieldInteract> fieldInteracts = new();
     private readonly ConcurrentDictionary<string, FieldFunctionInteract> fieldFunctionInteracts = new();
     private readonly ConcurrentDictionary<string, FieldInteract> fieldAdBalloons = new();
+    private readonly ConcurrentDictionary<string, FieldInteract> fieldChests = new();
     private readonly ConcurrentDictionary<int, FieldInstrument> fieldInstruments = new();
     private readonly ConcurrentDictionary<int, FieldItem> fieldItems = new();
     private readonly ConcurrentDictionary<int, FieldMobSpawn> fieldMobSpawns = new();
+    private readonly ConcurrentDictionary<int, FieldSpawnPointNpc> fieldSpawnPointNpcs = new();
+    private readonly ConcurrentDictionary<int, FieldSpawnGroup> fieldSpawnGroups = new();
     private readonly ConcurrentDictionary<int, FieldSkill> fieldSkills = new();
     private readonly ConcurrentDictionary<int, FieldPortal> fieldPortals = new();
 
@@ -106,7 +111,7 @@ public partial class FieldManager {
             Position = spawnPosition,
             Rotation = rotation,
             Origin = owner?.Position ?? spawnPosition,
-            SpawnPointId = owner?.Value.Id ?? NextGlobalId(),
+            SpawnPointId = owner?.Value.Id ?? 0,
         };
 
         if (npc.Basic.Friendly > 0) {
@@ -118,7 +123,7 @@ public partial class FieldManager {
         return fieldNpc;
     }
 
-    private FieldNpc? SpawnNpc(NpcMetadata npc, SpawnPointNPC spawnPointNpc) {
+    public FieldNpc? SpawnNpc(NpcMetadata npc, SpawnPointNPC spawnPointNpc) {
         return SpawnNpc(npc, spawnPointNpc.Position, spawnPointNpc.Rotation, null, spawnPointNpc);
     }
 
@@ -346,6 +351,60 @@ public partial class FieldManager {
         return fieldMobSpawn;
     }
 
+    public FieldSpawnPointNpc AddSpawnPointNpc(SpawnPointNPC metadata) {
+        var fieldSpawnPointNpc = new FieldSpawnPointNpc(this, NextLocalId(), metadata) {
+            Position = metadata.Position,
+            Rotation = metadata.Rotation,
+        };
+
+        fieldSpawnPointNpcs[metadata.Id] = fieldSpawnPointNpc;
+        fieldSpawnPointNpc.SpawnOnCreate();
+        return fieldSpawnPointNpc;
+    }
+
+    public void ToggleCombineSpawn(SpawnGroupMetadata metadata, bool enable) {
+        if (!fieldSpawnGroups.TryGetValue(metadata.GroupId, out FieldSpawnGroup? fieldSpawnGroup)) {
+            fieldSpawnGroup = new FieldSpawnGroup(this, NextLocalId(), metadata);
+            fieldSpawnGroups[metadata.GroupId] = fieldSpawnGroup;
+        }
+
+        fieldSpawnGroup.ToggleActive(enable);
+    }
+
+    public void ToggleNpcSpawnPoint(int spawnId) {
+        if (!fieldSpawnPointNpcs.TryGetValue(spawnId, out FieldSpawnPointNpc? fieldSpawnGroup)) {
+            return;
+        }
+
+        fieldSpawnGroup.TriggerSpawn();
+    }
+
+    public void SpawnInteractObject(SpawnInteractObjectMetadata metadata) {
+        if (!Entities.BoxRegionSpawns.TryGetValue(metadata.RegionSpawnId, out Ms2RegionBoxSpawn? boxSpawn) ||
+            !TableMetadata.InteractObjectTable.Entries.TryGetValue(metadata.InteractId, out InteractObjectMetadata? interactObjectMetadata)) {
+            return;
+        }
+        Vector3B position = boxSpawn.Position;
+
+        var interactObject = new InteractMeshObject($"EventCreate_{position.ConvertToInt()}", new Ms2InteractMesh(
+            metadata.InteractId, boxSpawn.Position, boxSpawn.Rotation)) {
+            Asset = metadata.Asset,
+            Model = metadata.Model,
+            NormalState = metadata.Normal,
+            Reactable = metadata.Reactable,
+            Scale = metadata.Scale,
+        };
+
+        var fieldInteract = new FieldInteract(this, NextLocalId(), interactObject.EntityId, interactObjectMetadata, interactObject) {
+            Transform = new Transform {
+                Position = boxSpawn.Position,
+                RotationAnglesDegrees = boxSpawn.Rotation,
+            },
+        };
+        fieldChests[interactObject.EntityId] = fieldInteract;
+        Broadcast(InteractObjectPacket.Add(fieldInteract.Object));
+    }
+
     public void AddSkill(SkillMetadata metadata, int interval, in Vector3 position, in Vector3 rotation = default) {
         var fieldSkill = new FieldSkill(this, NextLocalId(), FieldActor, metadata, interval, position) {
             Position = position,
@@ -444,6 +503,15 @@ public partial class FieldManager {
     public void RemoveFieldProperty(FieldProperty fieldProperty) {
         fieldProperties.Remove(fieldProperty, out _);
         Broadcast(FieldPropertyPacket.Remove(fieldProperty));
+    }
+
+    public IFieldProperty GetFieldProperty(FieldProperty type) {
+        if (fieldProperties.TryGetValue(type, out IFieldProperty? fieldProperty)) {
+            return fieldProperty;
+        }
+        fieldProperty = new FieldPropertySightRange();
+        AddFieldProperty(fieldProperty);
+        return fieldProperty;
     }
 
     public void SetBackground(string ddsPath) {
@@ -585,26 +653,36 @@ public partial class FieldManager {
         return true;
     }
 
-    public bool RemoveInteract(IInteractObject interactObject) {
-        switch (interactObject) {
-            case InteractBillBoardObject billboard:
-                fieldAdBalloons.TryRemove(billboard.EntityId, out _);
-                break;
-            default:
-                fieldInteracts.TryRemove(interactObject.EntityId, out _);
-                break;
-        }
-
-        Broadcast(InteractObjectPacket.Remove(interactObject.EntityId));
-        return true;
-    }
-
-    public bool RemoveNpc(int objectId, int removeDelay = 0) {
-        if (!Mobs.TryRemove(objectId, out FieldNpc? npc) && !Npcs.TryRemove(objectId, out npc)) {
+    public bool RemoveInteract(IInteractObject interactObject, int removeDelay = 0) {
+        if (!fieldAdBalloons.ContainsKey(interactObject.EntityId) && !fieldInteracts.ContainsKey(interactObject.EntityId)) {
             return false;
         }
 
         Scheduler.Schedule(() => {
+            switch (interactObject) {
+                case InteractBillBoardObject billboard:
+                    fieldAdBalloons.TryRemove(billboard.EntityId, out _);
+                    break;
+                default:
+                    fieldInteracts.TryRemove(interactObject.EntityId, out _);
+                    break;
+            }
+
+            Broadcast(InteractObjectPacket.Remove(interactObject.EntityId));
+        }, removeDelay);
+        return true;
+    }
+
+    public bool RemoveNpc(int objectId, int removeDelay = 0) {
+        if (!Mobs.TryGetValue(objectId, out FieldNpc? npc) && !Npcs.TryGetValue(objectId, out npc)) {
+            return false;
+        }
+
+        Scheduler.Schedule(() => {
+            if (!Mobs.TryRemove(objectId, out FieldNpc? npc) && !Npcs.TryRemove(objectId, out npc)) {
+                // Already removed
+                return;
+            }
             Broadcast(FieldPacket.RemoveNpc(objectId));
             Broadcast(ProxyObjectPacket.RemoveNpc(objectId));
             npc.Dispose();
@@ -652,6 +730,9 @@ public partial class FieldManager {
         added.Session.Send(BreakablePacket.Update(fieldBreakables.Values));
         added.Session.Send(InteractObjectPacket.Load(fieldInteracts.Values));
         foreach (FieldInteract fieldInteract in fieldAdBalloons.Values) {
+            added.Session.Send(InteractObjectPacket.Add(fieldInteract.Object));
+        }
+        foreach (FieldInteract fieldInteract in fieldChests.Values) {
             added.Session.Send(InteractObjectPacket.Add(fieldInteract.Object));
         }
         foreach (FieldInstrument fieldInstrument in fieldInstruments.Values) {

--- a/Maple2.Server.Game/Model/Field/Entity/FieldInteract.cs
+++ b/Maple2.Server.Game/Model/Field/Entity/FieldInteract.cs
@@ -18,6 +18,7 @@ public class FieldInteract : FieldEntity<InteractObjectMetadata> {
 
     private int reactLimit;
     public InteractState State { get; private set; }
+    public int SpawnId { get; init; }
 
     public FieldInteract(FieldManager field, int objectId, string entityId, InteractObjectMetadata value, IInteractObject interactObject) : base(field, objectId, value) {
         EntityId = entityId;

--- a/Maple2.Server.Game/Model/Field/Entity/FieldNpcSpawnPoint.cs
+++ b/Maple2.Server.Game/Model/Field/Entity/FieldNpcSpawnPoint.cs
@@ -7,14 +7,12 @@ namespace Maple2.Server.Game.Model;
 
 public class FieldSpawnPointNpc : FieldEntity<SpawnPointNPC> {
     private readonly List<int> spawnedMobs;
-    private readonly List<int> spawnedPets;
     private int SpawnId => Value.Id;
 
     private bool active;
 
     public FieldSpawnPointNpc(FieldManager field, int objectId, SpawnPointNPC metadata) : base(field, objectId, metadata) {
         spawnedMobs = [];
-        spawnedPets = [];
         if (metadata.RegenCheckTime > 0) {
             active = true;
         }

--- a/Maple2.Server.Game/Model/Field/Entity/FieldNpcSpawnPoint.cs
+++ b/Maple2.Server.Game/Model/Field/Entity/FieldNpcSpawnPoint.cs
@@ -1,0 +1,49 @@
+﻿using Maple2.Model.Metadata;
+using Maple2.Server.Game.Manager.Field;
+using Maple2.Server.Game.Packets;
+using Serilog;
+
+namespace Maple2.Server.Game.Model;
+
+public class FieldSpawnPointNpc : FieldEntity<SpawnPointNPC> {
+    private readonly List<int> spawnedMobs;
+    private readonly List<int> spawnedPets;
+    private int SpawnId => Value.Id;
+
+    private bool active;
+
+    public FieldSpawnPointNpc(FieldManager field, int objectId, SpawnPointNPC metadata) : base(field, objectId, metadata) {
+        spawnedMobs = [];
+        spawnedPets = [];
+        if (metadata.RegenCheckTime > 0) {
+            active = true;
+        }
+    }
+
+    public void SpawnOnCreate() {
+        if (Value.SpawnOnFieldCreate) {
+            TriggerSpawn();
+        }
+    }
+
+    public void TriggerSpawn() {
+        foreach (SpawnPointNPCListEntry spawn in Value.NpcList) {
+            if (!Field.NpcMetadata.TryGet(spawn.NpcId, out NpcMetadata? npcMetadata)) {
+                Log.Logger.Warning("Npc {NpcId} failed to load for map {MapId}", spawn.NpcId, Field.MapId);
+                continue;
+            }
+
+            for (int i = 0; i < spawn.Count; i++) {
+                FieldNpc? npc = Field.SpawnNpc(npcMetadata, Value);
+                if (npc == null) {
+                    continue;
+                }
+                npc.SpawnPointId = 0;
+
+                Field.Broadcast(FieldPacket.AddNpc(npc));
+                Field.Broadcast(ProxyObjectPacket.AddNpc(npc));
+                spawnedMobs.Add(npc.ObjectId);
+            }
+        }
+    }
+}

--- a/Maple2.Server.Game/Model/Field/Entity/FieldSpawnGroup.cs
+++ b/Maple2.Server.Game/Model/Field/Entity/FieldSpawnGroup.cs
@@ -1,0 +1,132 @@
+﻿using Maple2.Model.Enum;
+using Maple2.Model.Metadata;
+using Maple2.Server.Game.Manager.Field;
+using Maple2.Tools;
+using Serilog;
+
+namespace Maple2.Server.Game.Model;
+
+public class FieldSpawnGroup : FieldEntity<SpawnGroupMetadata> {
+
+    private readonly WeightedSet<SpawnNpcMetadata> npcs;
+    private readonly WeightedSet<SpawnInteractObjectMetadata> interactObjects;
+    private readonly List<int> spawnIds = [];
+    private long resetTick;
+
+    private bool active;
+
+    public FieldSpawnGroup(FieldManager field, int objectId, SpawnGroupMetadata metadata) : base(field, objectId, metadata) {
+        resetTick = metadata.ResetTick + field.FieldTick;
+        npcs = new WeightedSet<SpawnNpcMetadata>();
+        interactObjects = new WeightedSet<SpawnInteractObjectMetadata>();
+        Init();
+    }
+
+    private void Init() {
+        switch (Value.Type) {
+            case CombineSpawnGroupType.npc:
+                if (!Field.ServerTableMetadata.CombineSpawnTable.Npcs.TryGetValue(Value.GroupId, out Dictionary<int, SpawnNpcMetadata>? npcDict)) {
+                    return;
+                }
+
+                foreach (SpawnNpcMetadata npc in npcDict.Values) {
+                    npcs.Add(npc, npc.Weight);
+                }
+                break;
+            case CombineSpawnGroupType.interactObject:
+                if (!Field.ServerTableMetadata.CombineSpawnTable.InteractObjects.TryGetValue(Value.GroupId, out Dictionary<int, SpawnInteractObjectMetadata>? interactDict)) {
+                    return;
+                }
+
+                foreach (SpawnInteractObjectMetadata interact in interactDict.Values) {
+                    interactObjects.Add(interact, interact.Weight);
+                }
+                break;
+            default:
+                Log.Logger.Error("Invalid spawn group type {Type} for spawn group {GroupId}", Value.Type, Value.GroupId);
+                break;
+        }
+    }
+
+    public void ToggleActive(bool active) {
+        this.active = active;
+
+        if (!active) {
+            spawnIds.Clear();
+        } else {
+            InitializeSpawns();
+        }
+    }
+
+    private void InitializeSpawns() {
+        if (Value.TotalCount <= 0) {
+            return;
+        }
+
+        switch (Value.Type) {
+            case CombineSpawnGroupType.npc:
+                SpawnNpcs();
+                return;
+            case CombineSpawnGroupType.interactObject:
+                SpawnInteractObjects();
+                return;
+        }
+    }
+
+    private void SpawnNpcs() {
+        var removedSpawnIds = new List<int>();
+        foreach (int spawnId in spawnIds) {
+            if (!Field.GetActorsBySpawnId(spawnId).Any()) {
+                removedSpawnIds.Add(spawnId);
+            }
+        }
+
+        foreach (int spawnId in removedSpawnIds) {
+            spawnIds.Remove(spawnId);
+        }
+
+        do {
+            SpawnNpcMetadata npc = npcs.Get();
+            if (spawnIds.Contains(npc.SpawnId)) {
+                continue;
+            }
+            Field.ToggleNpcSpawnPoint(npc.SpawnId);
+            spawnIds.Add(npc.SpawnId);
+        } while (Value.TotalCount > spawnIds.Count);
+    }
+
+    private void SpawnInteractObjects() {
+        var removedSpawnIds = new List<int>();
+        foreach (int spawnId in spawnIds) {
+            if (!Field.GetInteractObjectsBySpawnId(spawnId).Any()) {
+                removedSpawnIds.Add(spawnId);
+            }
+        }
+
+        foreach (int spawnId in removedSpawnIds) {
+            spawnIds.Remove(spawnId);
+        }
+
+        do {
+            SpawnInteractObjectMetadata interactObject = interactObjects.Get();
+            if (spawnIds.Contains(interactObject.RegionSpawnId)) {
+                continue;
+            }
+            Field.SpawnInteractObject(interactObject);
+            spawnIds.Add(interactObject.RegionSpawnId);
+        } while (Value.TotalCount > spawnIds.Count);
+    }
+
+    public override void Update(long tickCount) {
+        if (!active) {
+            return;
+        }
+
+        if (tickCount < resetTick) {
+            return;
+        }
+
+        InitializeSpawns();
+        resetTick = Field.FieldTick + Value.ResetTick;
+    }
+}

--- a/Maple2.Server.Game/Model/Field/Entity/FieldSpawnGroup.cs
+++ b/Maple2.Server.Game/Model/Field/Entity/FieldSpawnGroup.cs
@@ -51,11 +51,12 @@ public class FieldSpawnGroup : FieldEntity<SpawnGroupMetadata> {
     public void ToggleActive(bool active) {
         this.active = active;
 
-        if (!active) {
-            spawnIds.Clear();
-        } else {
+        if (active) {
             InitializeSpawns();
+            return;
         }
+
+        spawnIds.Clear();
     }
 
     private void InitializeSpawns() {
@@ -85,6 +86,7 @@ public class FieldSpawnGroup : FieldEntity<SpawnGroupMetadata> {
             spawnIds.Remove(spawnId);
         }
 
+        int totalCount = Math.Clamp(Value.TotalCount, 0, npcs.Count);
         do {
             SpawnNpcMetadata npc = npcs.Get();
             if (spawnIds.Contains(npc.SpawnId)) {
@@ -92,7 +94,7 @@ public class FieldSpawnGroup : FieldEntity<SpawnGroupMetadata> {
             }
             Field.ToggleNpcSpawnPoint(npc.SpawnId);
             spawnIds.Add(npc.SpawnId);
-        } while (Value.TotalCount > spawnIds.Count);
+        } while (totalCount > spawnIds.Count);
     }
 
     private void SpawnInteractObjects() {
@@ -107,6 +109,7 @@ public class FieldSpawnGroup : FieldEntity<SpawnGroupMetadata> {
             spawnIds.Remove(spawnId);
         }
 
+        int totalCount = Math.Clamp(Value.TotalCount, 0, interactObjects.Count);
         do {
             SpawnInteractObjectMetadata interactObject = interactObjects.Get();
             if (spawnIds.Contains(interactObject.RegionSpawnId)) {
@@ -114,7 +117,7 @@ public class FieldSpawnGroup : FieldEntity<SpawnGroupMetadata> {
             }
             Field.SpawnInteractObject(interactObject);
             spawnIds.Add(interactObject.RegionSpawnId);
-        } while (Value.TotalCount > spawnIds.Count);
+        } while (totalCount > spawnIds.Count);
     }
 
     public override void Update(long tickCount) {

--- a/Maple2.Server.Game/Model/Field/Widget/SurvivalContentsWidget.cs
+++ b/Maple2.Server.Game/Model/Field/Widget/SurvivalContentsWidget.cs
@@ -4,6 +4,8 @@ using System.Reflection;
 using Maple2.PacketLib.Tools;
 using Maple2.Server.Game.Manager.Field;
 using Maple2.Tools;
+using Serilog;
+using Serilog.Core;
 
 namespace Maple2.Server.Game.Model.Widget;
 
@@ -13,12 +15,24 @@ public class SurvivalContentsWidget : Widget, IByteSerializable {
 
     public SurvivalContentsWidget(FieldManager field) : base(field) {
         Conditions = new ConcurrentDictionary<string, int>();
+        StormCenter = new Vector3(0, 0, 0);
+        SafeZoneCenter = new Vector3(0, 0, 0);
     }
 
     public override void Action(string function, int numericArg, string stringArg) {
-        MethodInfo? method = GetType().GetMethod(function, BindingFlags.NonPublic | BindingFlags.Instance);
-        if (method != null) {
-            method.Invoke(this, [stringArg, numericArg]);
+        switch (function) {
+            case "StormData":
+                StormData(stringArg);
+                break;
+            case "EnterStep":
+                EnterStep(stringArg);
+                break;
+            case "ExitStep":
+                ExitStep(stringArg);
+                break;
+            default:
+                Log.Logger.Warning($"Unknown function called on SurvivalContentsWidget: {function}");
+                break;
         }
     }
 

--- a/Maple2.Server.Game/Model/Field/Widget/SurvivalContentsWidget.cs
+++ b/Maple2.Server.Game/Model/Field/Widget/SurvivalContentsWidget.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Concurrent;
+using System.Numerics;
+using System.Reflection;
+using Maple2.PacketLib.Tools;
+using Maple2.Server.Game.Manager.Field;
+using Maple2.Tools;
+
+namespace Maple2.Server.Game.Model.Widget;
+
+public class SurvivalContentsWidget : Widget, IByteSerializable {
+    private Vector3 StormCenter;
+    private Vector3 SafeZoneCenter;
+
+    public SurvivalContentsWidget(FieldManager field) : base(field) {
+        Conditions = new ConcurrentDictionary<string, int>();
+    }
+
+    public override void Action(string function, int numericArg, string stringArg) {
+        MethodInfo? method = GetType().GetMethod(function, BindingFlags.NonPublic | BindingFlags.Instance);
+        if (method != null) {
+            method.Invoke(this, [stringArg, numericArg]);
+        }
+    }
+
+    private void StormData(string step) {
+
+    }
+
+    private void EnterStep(string step) {
+    }
+
+    private void ExitStep(string step) {
+
+    }
+
+    public void WriteTo(IByteWriter writer) {
+        writer.WriteShort(500);
+        writer.WriteShort(3000); // radius
+        writer.WriteShort(1000);
+        writer.Write<Vector3>(StormCenter);
+        writer.WriteShort(1000); // radius of center
+        writer.Write<Vector3>(SafeZoneCenter);
+    }
+}

--- a/Maple2.Server.Game/PacketHandlers/ItemPickupHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/ItemPickupHandler.cs
@@ -1,6 +1,7 @@
 ﻿using Maple2.Model;
 using Maple2.Model.Enum;
 using Maple2.Model.Game;
+using Maple2.Model.Metadata;
 using Maple2.PacketLib.Tools;
 using Maple2.Server.Core.Constants;
 using Maple2.Server.Core.PacketHandlers;
@@ -51,6 +52,14 @@ public class ItemPickupHandler : PacketHandler<GameSession> {
             }
 
             session.ConditionUpdate(ConditionType.item_pickup, counter: item.Amount, codeLong: item.Id);
+
+            // Items with Pick up effects are not added to player inventory.
+            if (item.Metadata.AdditionalEffects.Any(buff => buff.PickUpEffect)) {
+                foreach (ItemMetadataAdditionalEffect additionalEffect in item.Metadata.AdditionalEffects.Where(buff => buff.PickUpEffect)) {
+                    session.Player.Buffs.AddBuff(session.Player, session.Player, additionalEffect.Id, additionalEffect.Level);
+                }
+                return;
+            }
 
             item.Slot = -1;
             if (session.Item.Inventory.Add(item, true) && item.Metadata.Limit.TransferType == TransferType.BindOnLoot) {

--- a/Maple2.Server.Game/PacketHandlers/UserChatHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/UserChatHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Numerics;
+using System.Text.RegularExpressions;
 using System.Xml;
 using Grpc.Core;
 using Maple2.Database.Storage;
@@ -9,7 +10,9 @@ using Maple2.PacketLib.Tools;
 using Maple2.Server.Core.Constants;
 using Maple2.Server.Core.PacketHandlers;
 using Maple2.Server.Core.Packets;
+using Maple2.Server.Game.Model;
 using Maple2.Server.Game.Packets;
+using Maple2.Server.Game.Scripting.Trigger;
 using Maple2.Server.Game.Session;
 using WorldClient = Maple2.Server.World.Service.World.WorldClient;
 

--- a/Maple2.Server.Game/Packets/SurvivalEventPacket.cs
+++ b/Maple2.Server.Game/Packets/SurvivalEventPacket.cs
@@ -7,10 +7,7 @@ using Maple2.Tools.Extensions;
 namespace Maple2.Server.Game.Packets;
 
 public static class SurvivalEventPacket {
-    private enum Command : byte {
-    }
-
-    public static ByteWriter Test(SurvivalContentsWidget widget) {
+    public static ByteWriter Update(SurvivalContentsWidget widget) {
         var pWriter = Packet.Of(SendOp.SurvivalEvent);
         pWriter.WriteByte(0); // bool lto enable?
         pWriter.WriteClass<SurvivalContentsWidget>(widget);

--- a/Maple2.Server.Game/Packets/SurvivalEventPacket.cs
+++ b/Maple2.Server.Game/Packets/SurvivalEventPacket.cs
@@ -1,0 +1,20 @@
+﻿using Maple2.PacketLib.Tools;
+using Maple2.Server.Core.Constants;
+using Maple2.Server.Core.Packets;
+using Maple2.Server.Game.Model.Widget;
+using Maple2.Tools.Extensions;
+
+namespace Maple2.Server.Game.Packets;
+
+public static class SurvivalEventPacket {
+    private enum Command : byte {
+    }
+
+    public static ByteWriter Test(SurvivalContentsWidget widget) {
+        var pWriter = Packet.Of(SendOp.SurvivalEvent);
+        pWriter.WriteByte(0); // bool lto enable?
+        pWriter.WriteClass<SurvivalContentsWidget>(widget);
+
+        return pWriter;
+    }
+}

--- a/Maple2.Server.Game/Packets/TriggerPacket.cs
+++ b/Maple2.Server.Game/Packets/TriggerPacket.cs
@@ -5,6 +5,7 @@ using Maple2.PacketLib.Tools;
 using Maple2.Server.Core.Constants;
 using Maple2.Server.Core.Packets;
 using Maple2.Server.Game.Model;
+using Maple2.Server.Game.Scripting.Trigger;
 using Maple2.Tools.Extensions;
 
 namespace Maple2.Server.Game.Packets;
@@ -22,7 +23,7 @@ public static class TriggerPacket {
         AddEffect = 16,
         RemoveEffect = 17,
         SidePopup = 18,
-        Unknown19 = 19,
+        SetVisibleUi = 19,
         DuelHpBar = 20,
         ResetScript = 21,
         Effect1 = 22,
@@ -107,39 +108,25 @@ public static class TriggerPacket {
         return pWriter;
     }
 
-    public static ByteWriter SidePopupTalk(int duration, string illustration, string voice, string script, string sound = "") {
+    public static ByteWriter SidePopupTalk(SideNpcTalkType type = SideNpcTalkType.Default, int duration = 0, string illustration = "", string voice = "", string script = "", string sound = "", string usm = "") {
         var pWriter = Packet.Of(SendOp.Trigger);
         pWriter.Write<Command>(Command.SidePopup);
-        pWriter.WriteInt(1); // Talk
+        pWriter.Write<SideNpcTalkType>(type);
         pWriter.WriteInt(duration);
-        pWriter.WriteString();
+        pWriter.WriteString(usm);
         pWriter.WriteString(illustration);
         pWriter.WriteString(voice);
-        pWriter.WriteString(sound); // sound?
+        pWriter.WriteString(sound);
         pWriter.WriteUnicodeString(script);
 
         return pWriter;
     }
 
-    public static ByteWriter SidePopupCutIn(int duration, string illustration) {
+    public static ByteWriter SetVisibleUi(bool visible, string uiNames) {
         var pWriter = Packet.Of(SendOp.Trigger);
-        pWriter.Write<Command>(Command.SidePopup);
-        pWriter.WriteInt(2); // CutIn
-        pWriter.WriteInt(duration);
-        pWriter.WriteString();
-        pWriter.WriteString(illustration);
-        pWriter.WriteString();
-        pWriter.WriteString(); // sound?
-        pWriter.WriteUnicodeString();
-
-        return pWriter;
-    }
-
-    public static ByteWriter Unknown19() {
-        var pWriter = Packet.Of(SendOp.Trigger);
-        pWriter.Write<Command>(Command.Unknown19);
-        pWriter.WriteByte();
-        pWriter.WriteString(); // comma delimited
+        pWriter.Write<Command>(Command.SetVisibleUi);
+        pWriter.WriteBool(visible);
+        pWriter.WriteString(uiNames);
 
         return pWriter;
     }

--- a/Maple2.Server.Game/Scripting/Trigger/TriggerEnums.cs
+++ b/Maple2.Server.Game/Scripting/Trigger/TriggerEnums.cs
@@ -12,3 +12,5 @@ public enum Locale { ALL, KR, CN, NA, JP, TH, TW }
 public enum Weather { Clear = 0, Snow = 1, HeavySnow = 2, Rain = 3, HeavyRain = 4, SandStorm = 5, CherryBlossom = 6, LeafFall = 7 }
 
 public enum BannerType : byte { Lose = 0, GameOver = 1, Winner = 2, Bonus = 3, Draw = 4, Success = 5, Text = 6, Fail = 7, Countdown = 8, }
+
+public enum SideNpcTalkType : byte { Default = 0, Movie = 1, CutIn = 2, TalkBottom = 3, Invasion = 4, Wedding = 5 }

--- a/Maple2.Server.Game/Trigger/TriggerContext.Field.cs
+++ b/Maple2.Server.Game/Trigger/TriggerContext.Field.cs
@@ -81,15 +81,14 @@ public partial class TriggerContext {
 
     public void SightRange(bool enabled, int range, int rangeZ, int border) {
         DebugLog("[SightRange] enabled:{Enabled}, range:{Range}, rangeZ:{RangeZ}, border:{Border}", enabled, range, rangeZ, border);
-        // range seems to be some ID? (3)
-        if (enabled) {
-            Field.AddFieldProperty(new FieldPropertySightRange {
-                Range = rangeZ,
-                Opacity = (byte) border,
-            });
-        } else {
-            Field.RemoveFieldProperty(FieldProperty.SightRange);
+        var sightRange = (Field.GetFieldProperty(FieldProperty.SightRange) as FieldPropertySightRange)!;
+        for (int i = 0; i < range; i++) {
+            sightRange.Fades[i] = rangeZ;
         }
+        sightRange.Opacity = (byte) (100 - border);
+        sightRange.Opaque = false;
+        sightRange.Unknown = enabled;
+        Broadcast(FieldPropertyPacket.Add(sightRange));
     }
 
     public void SetPvpZone(int boxId, int prepareTime, int matchTime, int additionalEffectId, int type, params int[] boxIds) {
@@ -442,13 +441,25 @@ public partial class TriggerContext {
     }
 
     public void StartCombineSpawn(int[] groupIds, bool isStart) {
-        ErrorLog("[StartCombineSpawn] groupIds:{Ids}, isStart:{IsStart}", string.Join(", ", groupIds), isStart);
+        DebugLog("[StartCombineSpawn] groupIds:{Ids}, isStart:{IsStart}", string.Join(", ", groupIds), isStart);
+        if (!Field.ServerTableMetadata.CombineSpawnTable.Groups.TryGetValue(Field.MapId, out Dictionary<int, SpawnGroupMetadata>? groupDict)) {
+            ErrorLog("[StartCombineSpawn] No group metadata found for map {MapId}", Field.MapId);
+            return;
+        }
+        foreach (int groupId in groupIds) {
+            if (!groupDict.TryGetValue(groupId, out SpawnGroupMetadata? group)) {
+                ErrorLog("[StartCombineSpawn] No group metadata found for group {GroupId}", groupId);
+                continue;
+            }
+
+            Field.ToggleCombineSpawn(group, isStart);
+        }
     }
 
-    public void SetTimer(string timerId, int seconds, bool autoRemove, bool display, int vOffset, string type, string desc) {
+    public void SetTimer(string timerId, int seconds, bool disableUi, bool autoRemove, int vOffset, string type, string desc) {
         DebugLog("[SetTimer] timerId:{Id}, seconds:{Seconds}", timerId, seconds);
-        Field.Timers[timerId] = new TickTimer(seconds * 1000, autoRemove, vOffset, display, type);
-        if (display) {
+        Field.Timers[timerId] = new TickTimer(seconds * 1000, autoRemove, vOffset, !disableUi, type);
+        if (!disableUi) {
             Broadcast(TriggerPacket.TimerDialog(Field.Timers[timerId]));
         }
     }

--- a/Maple2.Server.Game/Trigger/TriggerContext.Interface.cs
+++ b/Maple2.Server.Game/Trigger/TriggerContext.Interface.cs
@@ -135,7 +135,8 @@ public partial class TriggerContext {
     }
 
     public void SetVisibleUi(string[] uiNames, bool visible) {
-        ErrorLog("[SetVisibleUI] uiNames:{UiNames}, visible:{Visible}", string.Join(", ", uiNames), visible);
+        DebugLog("[SetVisibleUI] uiNames:{UiNames}, visible:{Visible}", string.Join(", ", uiNames), visible);
+        Broadcast(TriggerPacket.SetVisibleUi(visible, string.Join(",", uiNames)));
     }
 
     public void ShowCountUi(string text, int stage, int count, int soundType) {
@@ -159,26 +160,28 @@ public partial class TriggerContext {
     }
 
     public void SideNpcTalk(int npcId, string illust, int duration, string script, string voice) {
-        WarnLog("[SideNpcTalkBottom] npcId:{NpcId}, illust:{Illustration}, duration:{Duration}, script:{Script}, voice:{Voice}",
+        DebugLog("[SideNpcTalkBottom] npcId:{NpcId}, illust:{Illustration}, duration:{Duration}, script:{Script}, voice:{Voice}",
             npcId, illust, duration, script, voice);
-        Broadcast(TriggerPacket.SidePopupTalk(duration, illust, voice, script));
+        Broadcast(TriggerPacket.SidePopupTalk(SideNpcTalkType.Default, duration, illust, voice, script));
     }
 
     public void SideNpcTalkBottom(int npcId, string illust, int duration, string script) {
-        WarnLog("[SideNpcTalkBottom] npcId:{NpcId}, illust:{Illustration}, duration:{Duration}, script:{Script}", npcId, illust, duration, script);
+        DebugLog("[SideNpcTalkBottom] npcId:{NpcId}, illust:{Illustration}, duration:{Duration}, script:{Script}", npcId, illust, duration, script);
+        Broadcast(TriggerPacket.SidePopupTalk(SideNpcTalkType.TalkBottom, duration, illust, string.Empty, script));
     }
 
     public void SideNpcMovie(string usm, int duration) {
-        WarnLog("[SideNpcMovie] usm:{Usm}, duration:{Duration}", usm, duration);
+        DebugLog("[SideNpcMovie] usm:{Usm}, duration:{Duration}", usm, duration);
+        Broadcast(TriggerPacket.SidePopupTalk(SideNpcTalkType.Movie, duration, usm: usm));
     }
 
     public void SideNpcCutin(string illust, int duration) {
-        WarnLog("[SideNpcMovie] illust:{Illustration}, duration:{Duration}", illust, duration);
-        Broadcast(TriggerPacket.SidePopupCutIn(duration, illust));
+        DebugLog("[SideNpcMovie] illust:{Illustration}, duration:{Duration}", illust, duration);
+        Broadcast(TriggerPacket.SidePopupTalk(SideNpcTalkType.CutIn, duration, illust));
     }
 
     public void WidgetAction(string type, string func, string widgetArg, string desc, int widgetArgNum) {
-        ErrorLog("[WidgetAction] type:{Type}, func:{Func}, widgetArg:{Args}, desc:{Desc}, widgetArgNum:{ArgNum}", type, func, widgetArg, desc, widgetArgNum);
+        DebugLog("[WidgetAction] type:{Type}, func:{Func}, widgetArg:{Args}, desc:{Desc}, widgetArgNum:{ArgNum}", type, func, widgetArg, desc, widgetArgNum);
         if (!Field.Widgets.TryGetValue(type, out Widget? widget)) {
             return;
         }


### PR DESCRIPTION
- This implements spawn groups needed for Mushking Royale and Kritias Invasion
- Implements looting items and applying buff if applicable
- Fixed a few triggers (setting visible ui, npc side talk cut in, movies, etc)
- Fixed timer showing up only when applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an advanced spawn system that supports region-specific and combined spawn groups for NPCs and interactive objects.
  - Added survival event functionality with a dedicated widget to enhance gameplay events.
  - Enabled a new defensive item action that temporarily summons protective NPCs.

- **Enhancements**
  - Improved item pickup behavior to apply special effects as buffs before adding items.
  - Refined field visuals with dynamic sight range adjustments for better environmental clarity.
  - Upgraded UI interactions and NPC dialogue triggers for smoother in-game communication.
  - Expanded metadata structures to include new spawn types and effects for enhanced gameplay mechanics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->