### PR TITLE
Multiple fixes

### DIFF
--- a/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.State.cs
+++ b/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.State.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using DotRecast.Detour.Crowd;
+using Maple2.Database.Storage;
 using Maple2.Model.Enum;
 using Maple2.Model.Game;
 using Maple2.Model.Metadata;
@@ -195,6 +196,11 @@ public partial class FieldManager {
     }
 
     public FieldItem SpawnItem(IActor owner, Item item) {
+        lock (item) {
+            using GameStorage.Request db = GameStorage.Context();
+            db.SaveItems(0, item);
+        }
+
         var fieldItem = new FieldItem(this, NextLocalId(), item) {
             Owner = owner,
             Position = owner.Position,

--- a/Maple2.Server.Game/Manager/Items/InventoryManager.cs
+++ b/Maple2.Server.Game/Manager/Items/InventoryManager.cs
@@ -650,10 +650,6 @@ public class InventoryManager {
         }
     }
 
-    public void AddItemToDelete(Item item) {
-        delete.Add(item);
-    }
-
     public void Save(GameStorage.Request db) {
         lock (session.Item) {
             db.SaveItems(0, delete.ToArray());

--- a/Maple2.Server.Game/Manager/Items/InventoryManager.cs
+++ b/Maple2.Server.Game/Manager/Items/InventoryManager.cs
@@ -650,6 +650,10 @@ public class InventoryManager {
         }
     }
 
+    public void AddItemToDelete(Item item) {
+        delete.Add(item);
+    }
+
     public void Save(GameStorage.Request db) {
         lock (session.Item) {
             db.SaveItems(0, delete.ToArray());

--- a/Maple2.Server.Game/Manager/Items/ItemCollection.cs
+++ b/Maple2.Server.Game/Manager/Items/ItemCollection.cs
@@ -225,7 +225,7 @@ public class ItemCollection : IEnumerable<Item> {
             // Update the slot mapping
             uidToSlot.Clear();
             short i = 0;
-            while (items[i] is { } item) {
+            while (i < items.Length && items[i] is { } item) {
                 item.Slot = i;
                 uidToSlot[items[i]!.Uid] = i;
                 i++;

--- a/Maple2.Server.Game/PacketHandlers/HomeBankHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/HomeBankHandler.cs
@@ -11,8 +11,8 @@ public class HomeBankHandler : PacketHandler<GameSession> {
     public override RecvOp OpCode => RecvOp.RequestHomeBank;
 
     private enum Command : byte {
-        Home = 0,
-        Premium = 1,
+        Home = 1,
+        Premium = 2,
     }
 
     public override void Handle(GameSession session, IByteReader packet) {
@@ -28,12 +28,12 @@ public class HomeBankHandler : PacketHandler<GameSession> {
                 session.Send(HomeBank(time));
                 return;
             case Command.Premium:
-                session.Send(HomeBank(DateTimeOffset.UtcNow.ToUnixTimeSeconds()));
+                session.Send(HomeBank());
                 return;
         }
     }
 
-    private static ByteWriter HomeBank(long time) {
+    private static ByteWriter HomeBank(long time = 0) {
         var pWriter = Packet.Of(SendOp.HomeBank);
         pWriter.WriteLong(time);
 

--- a/Maple2.Server.Game/PacketHandlers/ItemInventoryHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/ItemInventoryHandler.cs
@@ -113,6 +113,7 @@ public class ItemInventoryHandler : PacketHandler<GameSession> {
             return;
         }
 
+        session.Item.Inventory.AddItemToDelete(drop);
         FieldItem fieldItem = session.Field!.SpawnItem(session.Player, drop);
         session.Field.Broadcast(FieldPacket.DropItem(fieldItem));
     }

--- a/Maple2.Server.Game/PacketHandlers/ItemInventoryHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/ItemInventoryHandler.cs
@@ -108,7 +108,7 @@ public class ItemInventoryHandler : PacketHandler<GameSession> {
             return;
         }
 
-        if (drop.Transfer == null || drop.IsExpired() || !drop.Transfer.Flag.HasFlag(TransferFlag.Trade) || !drop.Transfer.Flag.HasFlag(TransferFlag.Split) || drop.Transfer.Flag.HasFlag(TransferFlag.Bind)) {
+        if (drop.Transfer == null || drop.IsExpired() || !drop.Transfer.Flag.HasFlag(TransferFlag.Trade) || !drop.Transfer.Flag.HasFlag(TransferFlag.Split) || drop.Transfer.Binding != null) {
             session.Item.Inventory.Discard(drop);
             return;
         }

--- a/Maple2.Server.Game/PacketHandlers/ItemInventoryHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/ItemInventoryHandler.cs
@@ -108,7 +108,7 @@ public class ItemInventoryHandler : PacketHandler<GameSession> {
             return;
         }
 
-        if (drop.Transfer == null || drop.IsExpired() || !drop.Transfer.Flag.HasFlag(TransferFlag.Trade) || !drop.Transfer.Flag.HasFlag(TransferFlag.Split)) {
+        if (drop.Transfer == null || drop.IsExpired() || !drop.Transfer.Flag.HasFlag(TransferFlag.Trade) || !drop.Transfer.Flag.HasFlag(TransferFlag.Split) || drop.Transfer.Flag.HasFlag(TransferFlag.Bind)) {
             session.Item.Inventory.Discard(drop);
             return;
         }

--- a/Maple2.Server.Game/PacketHandlers/ItemInventoryHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/ItemInventoryHandler.cs
@@ -113,7 +113,6 @@ public class ItemInventoryHandler : PacketHandler<GameSession> {
             return;
         }
 
-        session.Item.Inventory.AddItemToDelete(drop);
         FieldItem fieldItem = session.Field!.SpawnItem(session.Player, drop);
         session.Field.Broadcast(FieldPacket.DropItem(fieldItem));
     }

--- a/Maple2.Server.Game/PacketHandlers/MasteryHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/MasteryHandler.cs
@@ -82,10 +82,10 @@ public class MasteryHandler : PacketHandler<GameSession> {
         }
 
         foreach (int questId in entry.RequiredQuests) {
-            if (!session.Quest.TryGetQuest(questId, out Quest? quest) || quest.State != QuestState.Completed) {
-                session.Send(MasteryPacket.Error(MasteryError.s_mastery_error_lack_quest));
-                return;
-            }
+            if (session.Quest.TryGetQuest(questId, out _)) continue;
+
+            session.Send(MasteryPacket.Error(MasteryError.s_mastery_error_lack_quest));
+            return;
         }
 
         if (session.Mastery[entry.Type] < entry.RequiredMastery) {

--- a/Maple2.Server.Game/PacketHandlers/QuestHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/QuestHandler.cs
@@ -201,6 +201,11 @@ public class QuestHandler : PacketHandler<GameSession> {
             return;
         }
 
+        if (metadata.GoToMapId is Constant.DefaultHomeMapId) {
+            session.MigrateToInstance(Constant.DefaultHomeMapId, session.AccountId);
+            return;
+        }
+
         session.Send(session.PrepareField(metadata.GoToMapId, metadata.GoToPortalId, session.CharacterId)
             ? FieldEnterPacket.Request(session.Player)
             : FieldEnterPacket.Error(MigrationError.s_move_err_default));

--- a/Maple2.Server.Game/Program.cs
+++ b/Maple2.Server.Game/Program.cs
@@ -39,6 +39,9 @@ CultureInfo.CurrentCulture = new("en-US");
 
 DotEnv.Load();
 
+// Check for the --instanced parameter
+bool overrideInstanced = args.Contains("--instanced");
+
 AddChannelResponse? response = null;
 try {
     GrpcChannel channel = GrpcChannel.ForAddress(Target.GrpcWorldUri);
@@ -46,9 +49,8 @@ try {
     response = worldClient.AddChannel(new AddChannelRequest {
         GameIp = Target.GameIp.ToString(),
         GrpcGameIp = Target.GrpcGameIp,
-        InstancedContent = Target.InstancedContent,
+        InstancedContent = overrideInstanced || Target.InstancedContent,
     });
-
 } catch (RpcException e) {
     Log.Error(e, "Failed to get port information from World Server. Is World Server running?");
     return;

--- a/Maple2.Server.Tests/Game/Manager/Item/ItemCollectionTest.cs
+++ b/Maple2.Server.Tests/Game/Manager/Item/ItemCollectionTest.cs
@@ -257,7 +257,102 @@ public class ItemCollectionTest {
             [5] = item3,
         };
 
-        CollectionAssert.AreEqual(new[] { item1, item2, item3 }, collection.ToList());
+        CollectionAssert.AreEqual(new[] {
+            item1,
+            item2,
+            item3
+        }, collection.ToList());
+    }
+
+    [Test]
+    public void TestSortFullInventory() {
+        var item1 = CreateItem(3000, rarity: 1, amount: 5);
+        var item2 = CreateItem(1000, rarity: 3, amount: 10);
+        var item3 = CreateItem(1000, rarity: 2, amount: 5);
+        var item4 = CreateItem(1000, rarity: 3, amount: 1);
+        var item5 = CreateItem(2000, rarity: 4, amount: 20);
+
+        // Create a full collection
+        var collection = new ItemCollection(5);
+        collection.Add(item1); // slot 0
+        collection.Add(item2); // slot 1
+        collection.Add(item3); // slot 2
+        collection.Add(item4); // slot 3
+        collection.Add(item5); // slot 4
+
+        // Verify it's full
+        Assert.That(collection.OpenSlots, Is.EqualTo(0));
+
+        // Sort the full inventory
+        collection.Sort();
+
+        // Verify items are sorted correctly
+        Assert.That(item3, Is.EqualTo(collection[0]));
+        Assert.That(item4, Is.EqualTo(collection[1]));
+        Assert.That(item2, Is.EqualTo(collection[2]));
+        Assert.That(item5, Is.EqualTo(collection[3]));
+        Assert.That(item1, Is.EqualTo(collection[4]));
+
+        // Verify all items still exist
+        Assert.That(collection.Count, Is.EqualTo(5));
+    }
+
+    [Test]
+    public void TestSortWithNullItems() {
+        var item1 = CreateItem(3000, rarity: 1, amount: 5);
+        var item2 = CreateItem(1000, rarity: 3, amount: 10);
+        var item3 = CreateItem(1000, rarity: 2, amount: 5);
+
+        // Create collection with gaps
+        var collection = new ItemCollection(10);
+        collection[2] = item1; // Insert at specific slots to create gaps
+        collection[5] = item2;
+        collection[8] = item3;
+
+        // Sort the inventory with gaps
+        collection.Sort();
+
+        // Verify items are sorted correctly with no gaps at the beginning
+        Assert.That(item3, Is.EqualTo(collection[0]));
+        Assert.That(item2, Is.EqualTo(collection[1]));
+        Assert.That(item1, Is.EqualTo(collection[2]));
+        Assert.IsNull(collection[3]);
+
+        // Verify all items still exist
+        Assert.That(collection.Count, Is.EqualTo(3));
+    }
+
+    [Test]
+    public void TestSortAfterRemoving() {
+        var item1 = CreateItem(3000, rarity: 1, amount: 5);
+        var item2 = CreateItem(1000, rarity: 3, amount: 10);
+        var item3 = CreateItem(1000, rarity: 2, amount: 5);
+        var item4 = CreateItem(1000, rarity: 3, amount: 1);
+        var item5 = CreateItem(2000, rarity: 4, amount: 20);
+
+        // Create a full collection
+        var collection = new ItemCollection(5);
+        collection.Add(item1);
+        collection.Add(item2);
+        collection.Add(item3);
+        collection.Add(item4);
+        collection.Add(item5);
+
+        // Remove an item, creating a gap
+        collection.RemoveSlot(2, out _);
+
+        // Sort the inventory with a gap
+        collection.Sort();
+
+        // Verify items are sorted correctly
+        Assert.That(item4, Is.EqualTo(collection[0]));
+        Assert.That(item2, Is.EqualTo(collection[1]));
+        Assert.That(item5, Is.EqualTo(collection[2]));
+        Assert.That(item1, Is.EqualTo(collection[3]));
+        Assert.IsNull(collection[4]);
+
+        // Verify item count
+        Assert.That(collection.Count, Is.EqualTo(4));
     }
 
     private static Model.Game.Item CreateItem(int id, int rarity = 1, int amount = 1) {
@@ -266,6 +361,8 @@ public class ItemCollectionTest {
         var fakeLimit = new ItemMetadataLimit(Gender.All, 0, 0, 4, true, true, true, true, true, false, false, 0, Array.Empty<JobCode>(), Array.Empty<JobCode>());
         var fakeLife = new ItemMetadataLife(0, 0);
         var fakeMetadata = new ItemMetadata(id, $"{id}", Array.Empty<EquipSlot>(), "", Array.Empty<DefaultHairMetadata>(), fakeLife, fakeProperty, fakeCustomize, fakeLimit, null, null, Array.Empty<ItemMetadataAdditionalEffect>(), null, null, null, null);
-        return new Model.Game.Item(fakeMetadata, rarity, amount) { Uid = Rng.NextInt64() };
+        return new Model.Game.Item(fakeMetadata, rarity, amount) {
+            Uid = Rng.NextInt64()
+        };
     }
 }

--- a/Maple2.Server.World/Containers/ChannelClientLookup.cs
+++ b/Maple2.Server.World/Containers/ChannelClientLookup.cs
@@ -67,7 +67,7 @@ public class ChannelClientLookup : IEnumerable<(int, ChannelClient)> {
             if (activeChannel is null) {
                 continue;
             }
-            if (activeChannel.Endpoint.Address.ToString() == gameIp && activeChannel.Status is ChannelStatus.Inactive) {
+            if (activeChannel.Endpoint.Address.ToString() == gameIp && activeChannel.Status is ChannelStatus.Inactive && activeChannel.InstancedContent == instancedContent) {
                 return (activeChannel.GamePort, activeChannel.GrpcPort, activeChannel.Id);
             }
         }


### PR DESCRIPTION
- Fix #342 
- Fix #354 
- Fix #356 
- Fix #353 
- Fix bank safe from inventory
- Added argument to start game server as instanced content only. Example: `dotnet run --instanced`
- Fixed fallback to first available channel when migrating instances

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced inventory sorting to prevent runtime errors.
  - Improved item drop processing to correctly handle bound items.
  - Refined home banking and guided navigation, ensuring smoother transitions.
  - Optimized selection and migration of game channels.
  - Strengthened item spawning with immediate data persistence for enhanced reliability.

- **New Features**
  - Introduced a startup option to enable instanced content.

- **Tests**
  - Expanded test coverage to verify correct sorting of inventory across various scenarios.
  - Added new tests for sorting functionality in the item collection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->