### PR TITLE
Liftable Cube Changes & Dungeon field maps inter room change

### DIFF
--- a/Maple2.Database/Storage/Game/GameStorage.Mail.cs
+++ b/Maple2.Database/Storage/Game/GameStorage.Mail.cs
@@ -110,7 +110,7 @@ public partial class GameStorage {
             Context.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.TrackAll;
 
             Model.Mail? mail = Context.Mail.Find(characterId, mailId);
-            if (mail == null || mail.ReadTime > DateTime.UnixEpoch) {
+            if (mail == null || mail.ReadTime > DateTime.Now) {
                 return null;
             }
 

--- a/Maple2.Database/Storage/Game/GameStorage.Map.cs
+++ b/Maple2.Database/Storage/Game/GameStorage.Map.cs
@@ -293,6 +293,7 @@ public partial class GameStorage {
                 Position = new Vector3B(model.X, model.Y, model.Z),
                 Rotation = model.Rotation,
                 Interact = ToInteractCube(model.Interact),
+                Type = PlotCube.CubeType.Construction,
             };
         }
 
@@ -309,6 +310,7 @@ public partial class GameStorage {
                 Position = new Vector3B(model.X, model.Y, model.Z),
                 Rotation = model.Rotation,
                 Interact = ToInteractCube(model.Interact),
+                Type = PlotCube.CubeType.Construction,
             };
         }
     }

--- a/Maple2.File.Ingest/Mapper/MapEntityMapper.cs
+++ b/Maple2.File.Ingest/Mapper/MapEntityMapper.cs
@@ -189,7 +189,7 @@ public class MapEntityMapper : TypeMapper<MapEntity> {
                             switch (physXProp) {
                                 case IMS2Liftable liftable:
                                     yield return new MapEntity(xblock, new Guid(entity.EntityId), entity.EntityName) {
-                                        Block = new Liftable((int) liftable.ItemID, liftable.ItemStackCount, liftable.ItemLifeTime, liftable.LiftableRegenCheckTime, liftable.LiftableFinishTime, liftable.MaskQuestID, liftable.MaskQuestState, liftable.EffectQuestID, liftable.EffectQuestState, liftable.Position, liftable.Rotation)
+                                        Block = new Liftable((int) liftable.ItemID, liftable.ItemStackCount, liftable.ItemLifeTime, liftable.LiftableRegenCheckTime, liftable.LiftableFinishTime, liftable.MaskQuestID, liftable.MaskQuestState, liftable.EffectQuestID, liftable.EffectQuestState, liftable.IsReactEffect, liftable.Position, liftable.Rotation)
                                     };
                                     continue;
                                 case IMS2TaxiStation taxiStation:

--- a/Maple2.Model/Game/Cube/PlotCube.cs
+++ b/Maple2.Model/Game/Cube/PlotCube.cs
@@ -10,7 +10,7 @@ public class PlotCube : HeldCube {
 
     public Vector3B Position { get; set; }
     public float Rotation { get; set; }
-    public CubeType Type { get; set; }
+    public required CubeType Type { get; set; }
 
     public int PlotId { get; set; }
 

--- a/Maple2.Model/Game/User/Character.cs
+++ b/Maple2.Model/Game/User/Character.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Numerics;
+﻿using System.Numerics;
 using Maple2.Model.Common;
 using Maple2.Model.Enum;
 

--- a/Maple2.Model/Game/User/IPlayerInfo.cs
+++ b/Maple2.Model/Game/User/IPlayerInfo.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Concurrent;
-using System.Collections.Generic;
-using Maple2.Model.Enum;
+﻿using Maple2.Model.Enum;
 
 namespace Maple2.Model.Game;
 

--- a/Maple2.Model/Game/User/PlayerInfo.cs
+++ b/Maple2.Model/Game/User/PlayerInfo.cs
@@ -30,7 +30,7 @@ public class PlayerInfo : CharacterInfo, IPlayerInfo, IByteSerializable {
             AchievementInfo = player.Character.AchievementInfo,
             PremiumTime = player.Character.PremiumTime,
             LastOnlineTime = player.Character.LastOnlineTime,
-            DungeonEnterLimits = [],
+            DungeonEnterLimits = player.Character.DungeonEnterLimits,
             GuildId = player.Character.GuildId,
             GuildName = player.Character.GuildName,
         };

--- a/Maple2.Model/Game/User/PlotInfo.cs
+++ b/Maple2.Model/Game/User/PlotInfo.cs
@@ -51,6 +51,12 @@ public class PlotInfo {
 
 public class Plot(UgcMapGroup metadata) : PlotInfo(metadata) {
     public readonly Dictionary<Vector3B, PlotCube> Cubes = new();
+    public static readonly Plot Default = new(new UgcMapGroup(0,
+        0,
+        0,
+        new UgcMapGroup.Cost(0, 0, 0),
+        new UgcMapGroup.Cost(0, 0, 0),
+        new UgcMapGroup.Limits(0,0,0,0,0,0)));
 
     public void SetPlannerMode(PlotMode mode) {
         PlotMode = mode;

--- a/Maple2.Model/Game/User/PlotInfo.cs
+++ b/Maple2.Model/Game/User/PlotInfo.cs
@@ -56,7 +56,7 @@ public class Plot(UgcMapGroup metadata) : PlotInfo(metadata) {
         0,
         new UgcMapGroup.Cost(0, 0, 0),
         new UgcMapGroup.Cost(0, 0, 0),
-        new UgcMapGroup.Limits(0,0,0,0,0,0)));
+        new UgcMapGroup.Limits(0, 0, 0, 0, 0, 0)));
 
     public void SetPlannerMode(PlotMode mode) {
         PlotMode = mode;

--- a/Maple2.Model/Metadata/MapEntity/Liftable.cs
+++ b/Maple2.Model/Metadata/MapEntity/Liftable.cs
@@ -12,6 +12,7 @@ public record Liftable(
     string MaskQuestState,
     string EffectQuestId,
     string EffectQuestState,
+    bool ReactEffect,
     Vector3 Position,
     Vector3 Rotation)
 : MapBlock;

--- a/Maple2.Server.Core/Sync/PlayerInfoUpdateExtensions.cs
+++ b/Maple2.Server.Core/Sync/PlayerInfoUpdateExtensions.cs
@@ -118,7 +118,6 @@ public static class PlayerInfoUpdateExtensions {
         if (type.HasFlag(UpdateField.Clubs)) {
             self.ClubIds = other.ClubIds;
         }
-
         if (type.HasFlag(UpdateField.Dungeon)) {
             self.DungeonEnterLimits = other.DungeonEnterLimits;
         }

--- a/Maple2.Server.Game/Manager/DungeonManager.cs
+++ b/Maple2.Server.Game/Manager/DungeonManager.cs
@@ -81,6 +81,15 @@ public class DungeonManager {
         }
 
         if (updated) {
+            session.PlayerInfo.SendUpdate(new PlayerUpdateRequest {
+                AccountId = session.AccountId,
+                CharacterId = session.CharacterId,
+                DungeonEnterLimits = { EnterLimits.Select(dungeon => new DungeonEnterLimitUpdate {
+                    DungeonId = dungeon.Key,
+                    Limit = (int) dungeon.Value,
+                })},
+                Async = true,
+            });
             session.Send(FieldEntrancePacket.Load(EnterLimits));
         }
     }
@@ -208,13 +217,6 @@ public class DungeonManager {
             if (Party.LeaderCharacterId != session.CharacterId) {
                 session.Send(DungeonRoomPacket.Error(DungeonRoomError.s_room_party_err_not_chief));
                 return;
-            }
-
-            foreach (PartyMember member in Party.Members.Values) {
-                if (!member.Info.DungeonEnterLimits.TryGetValue(dungeonId, out DungeonEnterLimit enterLimit) || enterLimit != DungeonEnterLimit.None) {
-                    //session.Send(DungeonRoomPacket.Error(DungeonRoomError));
-                    return;
-                }
             }
         }
 

--- a/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.State.cs
+++ b/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.State.cs
@@ -656,7 +656,10 @@ public partial class FieldManager {
             return false;
         }
 
-        Broadcast(CubePacket.RemoveCube(fieldLiftable.ObjectId, fieldLiftable.Position));
+        if (Plots[0].Cubes.Remove(fieldLiftable.Position)) {
+            Broadcast(CubePacket.RemoveCube(fieldLiftable.ObjectId, fieldLiftable.Position));
+        }
+
         Broadcast(LiftablePacket.Remove(entityId));
         return true;
     }
@@ -735,7 +738,10 @@ public partial class FieldManager {
     public void OnAddPlayer(FieldPlayer added) {
         Players[added.ObjectId] = added;
         // LOAD:
-        added.Session.Send(LiftablePacket.Update(fieldLiftables.Values));
+        foreach (FieldLiftable liftable in fieldLiftables.Values.Where(liftable => liftable.FinishTick > 0)) {
+            added.Session.Send(LiftablePacket.Add(liftable));
+        }
+        added.Session.Send(LiftablePacket.Update(fieldLiftables.Values.Where(liftable => liftable.FinishTick == 0).ToList()));
         added.Session.Send(BreakablePacket.Update(fieldBreakables.Values));
         added.Session.Send(InteractObjectPacket.Load(fieldInteracts.Values));
         foreach (FieldInteract fieldInteract in fieldAdBalloons.Values) {

--- a/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.Ugc.cs
+++ b/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.Ugc.cs
@@ -151,11 +151,7 @@ public partial class FieldManager {
                 }
 
                 Broadcast(LiftablePacket.Add(fieldLiftable));
-                if (plot.Cubes.TryAdd(position, new PlotCube(itemMetadata, liftable.Id) {
-                        Type = PlotCube.CubeType.Liftable,
-                        Position = position,
-                        Rotation = rotation,
-                    })) {
+                if (plot.Cubes.TryAdd(position, new PlotCube(itemMetadata, liftable.Id) { Type = PlotCube.CubeType.Liftable, Position = position, Rotation = rotation})) {
                     Broadcast(CubePacket.PlaceLiftable(session.Player.ObjectId, liftable, position, rotation));
                 }
                 Broadcast(SetCraftModePacket.Stop(session.Player.ObjectId));

--- a/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.Ugc.cs
+++ b/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.Ugc.cs
@@ -99,6 +99,7 @@ public partial class FieldManager {
             case PlotCube _:
                 if (itemMetadata.Install is null || itemMetadata.Housing is null) {
                     logger.Error($"Item {cubeItem.ItemId} is not a housing item.");
+                    return;
                 }
                 plot = session.Housing.GetFieldPlot();
                 if (plot == null) {

--- a/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.Ugc.cs
+++ b/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.Ugc.cs
@@ -1,8 +1,12 @@
 ﻿using System.Collections.Concurrent;
+using System.Numerics;
 using Maple2.Database.Storage;
+using Maple2.Model.Common;
+using Maple2.Model.Enum;
 using Maple2.Model.Game;
 using Maple2.Model.Game.Ugc;
-using Maple2.Server.Core.Packets;
+using Maple2.Model.Metadata;
+using Maple2.Server.Game.Model;
 using Maple2.Server.Game.Model.Field;
 using Maple2.Server.Game.Packets;
 using Maple2.Server.Game.Session;
@@ -83,5 +87,82 @@ public partial class FieldManager {
                 }
             }
         }
+    }
+
+    public void PlaceCube(GameSession session, HeldCube cubeItem, in Vector3B position, float rotation) {
+        Plot? plot = session.Field.Plots[0];
+        if (!session.ItemMetadata.TryGet(cubeItem.ItemId, out ItemMetadata? itemMetadata)) {
+            logger.Error("Failed to get item metadata for cube {cubeId}.", cubeItem.ItemId);
+            return;
+        }
+        switch (session.HeldCube) {
+            case PlotCube _:
+                if (itemMetadata.Install is null || itemMetadata.Housing is null) {
+                    logger.Error($"Item {cubeItem.ItemId} is not a housing item.");
+                }
+                plot = session.Housing.GetFieldPlot();
+                if (plot == null) {
+                    return;
+                }
+
+                if (!session.Housing.TryPlaceCube(cubeItem, plot, itemMetadata, position, rotation, out PlotCube? plotCube)) {
+                    return;
+                }
+
+                session.Field.Broadcast(CubePacket.PlaceCube(session.Player.ObjectId, plot, plotCube));
+
+                if (plotCube.Interact is not null) {
+                    if (plotCube.Interact.Nurturing is not null && plotCube.Interact.Metadata.Nurturing is not null) {
+                        using GameStorage.Request db = session.GameStorage.Context();
+                        Nurturing? nurturing = db.GetNurturing(session.AccountId, plotCube.ItemId, plotCube.Interact.Metadata.Nurturing);
+                        if (nurturing is null) {
+                            nurturing = db.CreateNurturing(session.AccountId, plotCube.Interact.Metadata.Nurturing, plotCube.Interact.Metadata.Id);
+                            if (nurturing is null) {
+                                lock (Plots) {
+                                    logger.Error("Failed to create Nurturing for {AccountId}, ItemId {ItemId}", session.AccountId, plotCube.ItemId);
+                                }
+                                return;
+                            }
+                        }
+                        plotCube.Interact.Nurturing = nurturing;
+                    }
+                    session.Field.Broadcast(FunctionCubePacket.AddFunctionCube(plotCube.Interact));
+                }
+
+                if (plot.IsPlanner) {
+                    return;
+                }
+                break;
+            case LiftableCube liftable:
+                FieldLiftable? fieldLiftable = session.Field.AddLiftable($"4_{position.ConvertToInt()}", liftable.Liftable);
+                if (fieldLiftable == null) {
+                    return;
+                }
+
+                session.HeldCube = null;
+                fieldLiftable.Count = 1;
+                fieldLiftable.State = LiftableState.Default;
+                fieldLiftable.Position = position;
+                fieldLiftable.Rotation = new Vector3(0, 0, rotation);
+                fieldLiftable.FinishTick = session.Field.FieldTick + fieldLiftable.Value.ItemLifetime;
+
+                if (session.Field.Entities.LiftableTargetBoxes.TryGetValue(position, out LiftableTargetBox? liftableTarget)) {
+                    session.ConditionUpdate(ConditionType.item_move, codeLong: cubeItem.ItemId, targetLong: liftableTarget.LiftableTarget);
+                }
+
+                Broadcast(LiftablePacket.Add(fieldLiftable));
+                if (plot.Cubes.TryAdd(position, new PlotCube(itemMetadata, liftable.Id) {
+                        Type = PlotCube.CubeType.Liftable,
+                        Position = position,
+                        Rotation = rotation,
+                    })) {
+                    Broadcast(CubePacket.PlaceLiftable(session.Player.ObjectId, liftable, position, rotation));
+                }
+                Broadcast(SetCraftModePacket.Stop(session.Player.ObjectId));
+                Broadcast(LiftablePacket.Update(fieldLiftable));
+                break;
+        }
+
+        session.ConditionUpdate(ConditionType.install_item, codeLong: cubeItem.ItemId);
     }
 }

--- a/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.Ugc.cs
+++ b/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.Ugc.cs
@@ -152,7 +152,7 @@ public partial class FieldManager {
                 }
 
                 Broadcast(LiftablePacket.Add(fieldLiftable));
-                if (plot.Cubes.TryAdd(position, new PlotCube(itemMetadata, liftable.Id) { Type = PlotCube.CubeType.Liftable, Position = position, Rotation = rotation})) {
+                if (plot.Cubes.TryAdd(position, new PlotCube(itemMetadata, liftable.Id) { Type = PlotCube.CubeType.Liftable, Position = position, Rotation = rotation })) {
                     Broadcast(CubePacket.PlaceLiftable(session.Player.ObjectId, liftable, position, rotation));
                 }
                 Broadcast(SetCraftModePacket.Stop(session.Player.ObjectId));

--- a/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.cs
+++ b/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.cs
@@ -125,6 +125,9 @@ public partial class FieldManager : IField {
             }
         }
 
+        // Create default to place liftable cubes
+        Plots[0] = Plot.Default;
+
         foreach (TriggerModel trigger in Entities.TriggerModels.Values) {
             AddTrigger(trigger);
         }

--- a/Maple2.Server.Game/Manager/Items/FurnishingManager.cs
+++ b/Maple2.Server.Game/Manager/Items/FurnishingManager.cs
@@ -104,7 +104,9 @@ public class FurnishingManager {
                 ? FurnishingStoragePacket.Update(item.Uid, item.Amount)
                 : FurnishingStoragePacket.Remove(item.Uid));
 
-            cube = new PlotCube(item.Metadata, NextCubeId(), item.Template);
+            cube = new PlotCube(item.Metadata, NextCubeId(), item.Template) {
+                Type = PlotCube.CubeType.Construction,
+            };
             if (!AddInventory(cube)) {
                 logger.Fatal("Failed to add cube: {CubeId} to inventory", cube.Id);
                 throw new InvalidOperationException($"Failed to add cube: {cube.Id} to inventory");

--- a/Maple2.Server.Game/PacketHandlers/RequestCubeHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/RequestCubeHandler.cs
@@ -219,64 +219,7 @@ public class RequestCubeHandler : PacketHandler<GameSession> {
             return;
         }
 
-        switch (session.HeldCube) {
-            case PlotCube _:
-                Plot? plot = session.Housing.GetFieldPlot();
-                if (plot == null) {
-                    return;
-                }
-
-                if (!session.Housing.TryPlaceCube(cubeItem, plot, position, rotation, out PlotCube? plotCube)) {
-                    return;
-                }
-
-                session.Field.Broadcast(CubePacket.PlaceCube(session.Player.ObjectId, plot, plotCube));
-
-                if (plotCube.Interact is not null) {
-                    if (plotCube.Interact.Nurturing is not null && plotCube.Interact.Metadata.Nurturing is not null) {
-                        using GameStorage.Request db = session.GameStorage.Context();
-                        Nurturing? nurturing = db.GetNurturing(session.AccountId, plotCube.ItemId, plotCube.Interact.Metadata.Nurturing);
-                        if (nurturing is null) {
-                            nurturing = db.CreateNurturing(session.AccountId, plotCube.Interact.Metadata.Nurturing, plotCube.Interact.Metadata.Id);
-                            if (nurturing is null) {
-                                Logger.Error("Failed to create Nurturing for {AccountId}, ItemId {ItemId}", session.AccountId, plotCube.ItemId);
-                                return;
-                            }
-                        }
-                        plotCube.Interact.Nurturing = nurturing;
-                    }
-                    session.Field.Broadcast(FunctionCubePacket.AddFunctionCube(plotCube.Interact));
-                }
-
-                if (plot.IsPlanner) {
-                    return;
-                }
-                break;
-            case LiftableCube liftable:
-                FieldLiftable? fieldLiftable = session.Field.AddLiftable(position.ToString(), liftable.Liftable);
-                if (fieldLiftable == null) {
-                    return;
-                }
-
-                session.HeldCube = null;
-                fieldLiftable.Count = 1;
-                fieldLiftable.State = LiftableState.Disabled;
-                fieldLiftable.Position = position;
-                fieldLiftable.Rotation = new Vector3(0, 0, rotation);
-                fieldLiftable.FinishTick = session.Field.FieldTick + fieldLiftable.Value.FinishTime + fieldLiftable.Value.ItemLifetime;
-
-                if (session.Field.Entities.LiftableTargetBoxes.TryGetValue(position, out LiftableTargetBox? liftableTarget)) {
-                    session.ConditionUpdate(ConditionType.item_move, codeLong: cubeItem.ItemId, targetLong: liftableTarget.LiftableTarget);
-                }
-
-                session.Field.Broadcast(LiftablePacket.Add(fieldLiftable));
-                session.Field.Broadcast(CubePacket.PlaceLiftable(session.Player.ObjectId, liftable, position, rotation));
-                session.Field.Broadcast(SetCraftModePacket.Stop(session.Player.ObjectId));
-                session.Field.Broadcast(LiftablePacket.Update(fieldLiftable));
-                break;
-        }
-
-        session.ConditionUpdate(ConditionType.install_item, codeLong: cubeItem.ItemId);
+        session.Field.PlaceCube(session, cubeItem, position, rotation);
     }
 
     private void HandleRemoveCube(GameSession session, IByteReader packet) {
@@ -337,7 +280,10 @@ public class RequestCubeHandler : PacketHandler<GameSession> {
             return;
         }
 
-        if (session.Housing.TryPlaceCube(cubeItem, plot, position, rotation, out PlotCube? placedCube, isReplace: true)) {
+        if (!session.ItemMetadata.TryGet(cubeItem.ItemId, out ItemMetadata? metdata)) {
+            return;
+        }
+        if (session.Housing.TryPlaceCube(cubeItem, plot, metdata, position, rotation, out PlotCube? placedCube, isReplace: true)) {
             session.Field?.Broadcast(CubePacket.ReplaceCube(session.Player.ObjectId, placedCube));
         }
     }

--- a/Maple2.Server.Game/PacketHandlers/UserChatHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/UserChatHandler.cs
@@ -299,7 +299,7 @@ public class UserChatHandler : PacketHandler<GameSession> {
         } catch (RpcException) { }
     }
 
-    private ICollection<long> LinkedItemUids(GameSession session, string message) {
+    private static ICollection<long> LinkedItemUids(GameSession session, string message) {
         List<long> itemUids = [];
 
         MatchCollection matches = Regex.Matches(message, "<A HREF=\"event:[^\"]+\">[^<]+</A>");

--- a/Maple2.Server.Game/Packets/LiftablePacket.cs
+++ b/Maple2.Server.Game/Packets/LiftablePacket.cs
@@ -20,14 +20,14 @@ public static class LiftablePacket {
         pWriter.WriteInt(liftables.Count);
         foreach (FieldLiftable liftable in liftables) {
             pWriter.WriteString(liftable.EntityId);
-            pWriter.WriteByte();
+            pWriter.WriteByte(1);
             pWriter.WriteInt(liftable.Count);
             pWriter.Write<LiftableState>(liftable.State);
             pWriter.WriteUnicodeString(liftable.Value.MaskQuestId);
             pWriter.WriteUnicodeString(liftable.Value.MaskQuestState);
             pWriter.WriteUnicodeString(liftable.Value.EffectQuestId);
             pWriter.WriteUnicodeString(liftable.Value.EffectQuestState);
-            pWriter.WriteBool(true);
+            pWriter.WriteBool(liftable.Value.ReactEffect);
         }
 
         return pWriter;
@@ -37,7 +37,7 @@ public static class LiftablePacket {
         var pWriter = Packet.Of(SendOp.Liftable);
         pWriter.Write<Command>(Command.Update);
         pWriter.WriteString(liftable.EntityId);
-        pWriter.WriteByte();
+        pWriter.WriteByte(1);
         pWriter.WriteInt(liftable.Count);
         pWriter.Write<LiftableState>(liftable.State);
 
@@ -53,7 +53,7 @@ public static class LiftablePacket {
         pWriter.WriteUnicodeString(liftable.Value.MaskQuestState);
         pWriter.WriteUnicodeString(liftable.Value.EffectQuestId);
         pWriter.WriteUnicodeString(liftable.Value.EffectQuestState);
-        pWriter.WriteBool(true); // UseEffect
+        pWriter.WriteBool(liftable.Value.ReactEffect);
 
         return pWriter;
     }

--- a/Maple2.Server.Game/Packets/LoadCubesPacket.cs
+++ b/Maple2.Server.Game/Packets/LoadCubesPacket.cs
@@ -27,7 +27,7 @@ public static class LoadCubesPacket {
             pWriter.WriteClass<PlotCube>(cube);
             pWriter.WriteInt(cube.PlotId);
             pWriter.WriteInt();
-            pWriter.WriteBool(false);
+            pWriter.WriteBool(cube.Type == PlotCube.CubeType.Liftable);
             pWriter.WriteFloat(cube.Rotation);
             pWriter.WriteInt();
             pWriter.WriteBool(false); // Binding?

--- a/Maple2.Server.Game/Packets/TriggerPacket.cs
+++ b/Maple2.Server.Game/Packets/TriggerPacket.cs
@@ -280,7 +280,7 @@ public static class TriggerPacket {
         pWriter.Write<Command>(Command.Ui);
         pWriter.Write<UiCommand>(UiCommand.FaceEmotion);
         pWriter.WriteInt(objectId);
-        pWriter.WriteUnicodeString(emotionName);
+        pWriter.WriteString(emotionName);
 
         return pWriter;
     }

--- a/Maple2.Server.Game/Session/GameSession.cs
+++ b/Maple2.Server.Game/Session/GameSession.cs
@@ -351,9 +351,13 @@ public sealed partial class GameSession : Core.Network.Session {
             ownerId = AccountId;
         }
 
-        newField = FieldFactory.Get(mapId, ownerId: ownerId, roomId: roomId);
-        if (newField == null) {
-            return false;
+        if (Field is DungeonFieldManager dungeonField && dungeonField.RoomFields.TryGetValue(mapId, out DungeonFieldManager? nextDungeonField)) {
+            newField = nextDungeonField;
+        } else {
+            newField = FieldFactory.Get(mapId, ownerId: ownerId, roomId: roomId);
+            if (newField == null) {
+                return false;
+            }
         }
 
         State = SessionState.ChangeMap;

--- a/Maple2.Server.Game/Util/Sync/PlayerInfoStorage.cs
+++ b/Maple2.Server.Game/Util/Sync/PlayerInfoStorage.cs
@@ -57,6 +57,7 @@ public class PlayerInfoStorage {
                 PlotExpiryTime = response.Home.ExpiryTime.Seconds,
                 PremiumTime = response.PremiumTime,
                 LastOnlineTime = response.LastOnlineTime,
+                DungeonEnterLimits = response.DungeonEnterLimits.ToDictionary(limit => limit.DungeonId, limit => (DungeonEnterLimit) limit.Limit),
             };
 
             cache[characterId] = info;


### PR DESCRIPTION
- Adjusted Liftable Cubes
  - Added a default plot on fields to properly spawn liftable cubes as plot cubes
  - Fixed the ability to be able to pick up liftable cubes after placing them down
- Now checks for dungeon sub rooms first if player is in a dungeon and changing maps. Allows for persistent room connections in a dungeon
- Fixed Mail read timestamp check.
- Fixed Sending DungeonEnterLimit updates on PlayerInfo (for party members)
- Fixed trigger packet on setting player/npc emotion via triggers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced cube placement functionality, allowing more precise in-game interactions for construction and liftable objects.
  - Added a default plot configuration to improve field initialization and overall game world consistency.
  - Enhanced `DungeonEnterLimits` property in player information for better dungeon management.
  - Added a new boolean property for liftable entities to indicate reaction effects.

- **Bug Fixes**
  - Improved mail read status logic for more accurate presentation.
  - Adjusted object type assignments and reaction effect propagation for consistent behavior.

- **Refactor**
  - Streamlined cube placement, dungeon limit updates, and liftable state management across game systems.
  - Simplified metadata handling in cube placement methods for improved efficiency.
  - Updated method signatures to enhance clarity and reduce complexity.

- **Chores**
  - Performed code cleanups and updated method interfaces to enhance data handling and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->