### PR TITLE
Fix: Selecting Previous Random Hair & Liftable Finish Tick

### DIFF
--- a/Maple2.Server.Game/Manager/BeautyManager.cs
+++ b/Maple2.Server.Game/Manager/BeautyManager.cs
@@ -82,7 +82,7 @@ public sealed class BeautyManager : IDisposable {
 
         // Making a copy due to previous hair being added to delete collection
         Item? previousHairCopy = previousHair.Clone();
-        GameStorage.Request db = session.GameStorage.Context();
+        using GameStorage.Request db = session.GameStorage.Context();
         previousHairCopy = db.CreateItem(session.CharacterId, previousHairCopy);
         if (previousHairCopy == null) {
             return;

--- a/Maple2.Server.Game/Manager/BeautyManager.cs
+++ b/Maple2.Server.Game/Manager/BeautyManager.cs
@@ -79,7 +79,15 @@ public sealed class BeautyManager : IDisposable {
         if (previousHair == null) {
             return;
         }
-        session.Item.Equips.EquipCosmetic(previousHair, EquipSlot.HR);
+
+        // Making a copy due to previous hair being added to delete collection
+        Item? previousHairCopy = previousHair.Clone();
+        GameStorage.Request db = session.GameStorage.Context();
+        previousHairCopy = db.CreateItem(session.CharacterId, previousHairCopy);
+        if (previousHairCopy == null) {
+            return;
+        }
+        session.Item.Equips.EquipCosmetic(previousHairCopy, EquipSlot.HR);
     }
 
     public void ClearPreviousHair() => previousHair = null;

--- a/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.Ugc.cs
+++ b/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.Ugc.cs
@@ -145,7 +145,7 @@ public partial class FieldManager {
                 fieldLiftable.State = LiftableState.Default;
                 fieldLiftable.Position = position;
                 fieldLiftable.Rotation = new Vector3(0, 0, rotation);
-                fieldLiftable.FinishTick = session.Field.FieldTick + fieldLiftable.Value.ItemLifetime;
+                fieldLiftable.FinishTick = session.Field.FieldTick + fieldLiftable.Value.ItemLifetime + fieldLiftable.Value.FinishTime;
 
                 if (session.Field.Entities.LiftableTargetBoxes.TryGetValue(position, out LiftableTargetBox? liftableTarget)) {
                     session.ConditionUpdate(ConditionType.item_move, codeLong: cubeItem.ItemId, targetLong: liftableTarget.LiftableTarget);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved hair customization: When reverting to a previous style, a duplicate is now used to ensure the original remains unaffected while streamlining the customization process.
  - Extended interactive object duration: Adjusted the timing so that certain in-game items remain active longer, supporting a smoother and more engaging gameplay experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->