### PR TITLE
Enchanting Material Cost Formula & Dungeon Record/Field Changes

### DIFF
--- a/Maple2.Database/Model/DungeonRecord.cs
+++ b/Maple2.Database/Model/DungeonRecord.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using Maple2.Database.Extensions;
+using Maple2.Model.Enum;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
@@ -10,45 +11,51 @@ internal class DungeonRecord {
     public long OwnerId { get; set; }
     public DateTime ClearTime { get; init; }
     public int TotalClears { get; init; }
-    public byte DailyClears { get; set; }
-    public byte WeeklyClears { get; set; }
+    public byte CurrentSubClears { get; set; }
+    public byte CurrentClears { get; set; }
     public short LifetimeRecord { get; set; }
-    public short WeeklyRecord { get; set; }
-    public byte ExtraDailyClears { get; set; }
-    public byte ExtraWeeklyClears { get; set; }
+    public short CurrentRecord { get; set; }
+    public byte ExtraCurrentSubClears { get; set; }
+    public byte ExtraCurrentClears { get; set; }
     public DateTime DailyResetTime { get; set; }
-    public DateTime WeeklyResetTime { get; set; }
+    public DateTime UnionCooldownTime { get; set; }
+    public DateTime CooldownTime { get; set; }
+    public DungeonRecordFlag Flag { get; set; }
 
     [return: NotNullIfNotNull(nameof(other))]
     public static implicit operator DungeonRecord?(Maple2.Model.Game.Dungeon.DungeonRecord? other) {
         return other == null ? null : new DungeonRecord {
             DungeonId = other.DungeonId,
-            DailyClears = other.DailyClears,
-            WeeklyClears = other.WeeklyClears,
-            DailyResetTime = other.DailyResetTimestamp.FromEpochSeconds(),
-            WeeklyResetTime = other.WeeklyResetTimestamp.FromEpochSeconds(),
+            CurrentSubClears = other.UnionSubClears,
+            CurrentClears = other.UnionClears,
+            DailyResetTime = other.UnionSubCooldownTimestamp.FromEpochSeconds(),
+            UnionCooldownTime = other.UnionCooldownTimestamp.FromEpochSeconds(),
             ClearTime = other.ClearTimestamp.FromEpochSeconds(),
+            CooldownTime = other.CooldownTimestamp.FromEpochSeconds(),
             TotalClears = other.TotalClears,
             LifetimeRecord = other.LifetimeRecord,
-            WeeklyRecord = other.WeeklyRecord,
-            ExtraDailyClears = other.ExtraDailyClears,
-            ExtraWeeklyClears = other.ExtraWeeklyClears,
+            CurrentRecord = other.CurrentRecord,
+            ExtraCurrentSubClears = other.ExtraSubClears,
+            ExtraCurrentClears = other.ExtraClears,
+            Flag = other.Flag,
         };
     }
 
     [return: NotNullIfNotNull(nameof(other))]
     public static implicit operator Maple2.Model.Game.Dungeon.DungeonRecord?(DungeonRecord? other) {
         return other == null ? null : new Maple2.Model.Game.Dungeon.DungeonRecord(other.DungeonId) {
-            DailyClears = other.DailyClears,
-            WeeklyClears = other.WeeklyClears,
-            DailyResetTimestamp = other.DailyResetTime.ToEpochSeconds(),
-            WeeklyResetTimestamp = other.WeeklyResetTime.ToEpochSeconds(),
+            UnionSubClears = other.CurrentSubClears,
+            UnionClears = other.CurrentClears,
+            UnionSubCooldownTimestamp = other.DailyResetTime.ToEpochSeconds(),
+            UnionCooldownTimestamp = other.UnionCooldownTime.ToEpochSeconds(),
             ClearTimestamp = other.ClearTime.ToEpochSeconds(),
+            CooldownTimestamp = other.CooldownTime.ToEpochSeconds(),
             TotalClears = other.TotalClears,
             LifetimeRecord = other.LifetimeRecord,
-            WeeklyRecord = other.WeeklyRecord,
-            ExtraDailyClears = other.ExtraDailyClears,
-            ExtraWeeklyClears = other.ExtraWeeklyClears,
+            CurrentRecord = other.CurrentRecord,
+            ExtraSubClears = other.ExtraCurrentSubClears,
+            ExtraClears = other.ExtraCurrentClears,
+            Flag = other.Flag,
         };
     }
 

--- a/Maple2.Database/Storage/Metadata/ServerTableMetadataStorage.cs
+++ b/Maple2.Database/Storage/Metadata/ServerTableMetadataStorage.cs
@@ -9,6 +9,7 @@ public class ServerTableMetadataStorage {
     private readonly Lazy<InstanceFieldTable> instanceFieldTable;
     private readonly Lazy<ScriptConditionTable> scriptConditionTable;
     private readonly Lazy<ScriptFunctionTable> scriptFunctionTable;
+    private readonly Lazy<ScriptEventConditionTable> scriptEventConditionTable;
     private readonly Lazy<JobConditionTable> jobConditionTable;
     private readonly Lazy<BonusGameTable> bonusGameTable;
     private readonly Lazy<GlobalDropItemBoxTable> globalDropItemBoxTable;
@@ -26,10 +27,12 @@ public class ServerTableMetadataStorage {
     private readonly Lazy<MeretMarketTable> meretMarketTable;
     private readonly Lazy<FishTable> fishTable;
     private readonly Lazy<CombineSpawnTable> combineSpawnTable;
+    private readonly Lazy<EnchantOptionTable> enchantOptionTable;
 
     public InstanceFieldTable InstanceFieldTable => instanceFieldTable.Value;
     public ScriptConditionTable ScriptConditionTable => scriptConditionTable.Value;
     public ScriptFunctionTable ScriptFunctionTable => scriptFunctionTable.Value;
+    public ScriptEventConditionTable ScriptEventConditionTable => scriptEventConditionTable.Value;
     public JobConditionTable JobConditionTable => jobConditionTable.Value;
     public BonusGameTable BonusGameTable => bonusGameTable.Value;
     public GlobalDropItemBoxTable GlobalDropItemBoxTable => globalDropItemBoxTable.Value;
@@ -47,11 +50,13 @@ public class ServerTableMetadataStorage {
     public MeretMarketTable MeretMarketTable => meretMarketTable.Value;
     public FishTable FishTable => fishTable.Value;
     public CombineSpawnTable CombineSpawnTable => combineSpawnTable.Value;
+    public EnchantOptionTable EnchantOptionTable => enchantOptionTable.Value;
 
     public ServerTableMetadataStorage(MetadataContext context) {
         instanceFieldTable = Retrieve<InstanceFieldTable>(context, ServerTableNames.INSTANCE_FIELD);
         scriptConditionTable = Retrieve<ScriptConditionTable>(context, ServerTableNames.SCRIPT_CONDITION);
         scriptFunctionTable = Retrieve<ScriptFunctionTable>(context, ServerTableNames.SCRIPT_FUNCTION);
+        scriptEventConditionTable = Retrieve<ScriptEventConditionTable>(context, ServerTableNames.SCRIPT_EVENT);
         jobConditionTable = Retrieve<JobConditionTable>(context, ServerTableNames.JOB_CONDITION);
         bonusGameTable = Retrieve<BonusGameTable>(context, ServerTableNames.BONUS_GAME);
         globalDropItemBoxTable = Retrieve<GlobalDropItemBoxTable>(context, ServerTableNames.GLOBAL_DROP_ITEM_BOX);
@@ -69,6 +74,7 @@ public class ServerTableMetadataStorage {
         meretMarketTable = Retrieve<MeretMarketTable>(context, ServerTableNames.MERET_MARKET);
         fishTable = Retrieve<FishTable>(context, ServerTableNames.FISH);
         combineSpawnTable = Retrieve<CombineSpawnTable>(context, ServerTableNames.COMBINE_SPAWN);
+        enchantOptionTable = Retrieve<EnchantOptionTable>(context, ServerTableNames.ENCHANT_OPTION);
     }
 
     public IEnumerable<GameEvent> GetGameEvents() {

--- a/Maple2.Database/Storage/Metadata/TableMetadataStorage.cs
+++ b/Maple2.Database/Storage/Metadata/TableMetadataStorage.cs
@@ -66,6 +66,8 @@ public class TableMetadataStorage {
 
     private readonly Lazy<DungeonRoomTable> dungeonRoomTable;
     private readonly Lazy<DungeonRankRewardTable> dungeonRankRewardTable;
+    private readonly Lazy<DungeonConfigTable> dungeonConfigTable;
+    private readonly Lazy<DungeonMissionTable> dungeonMissionTable;
 
     public ChatStickerTable ChatStickerTable => chatStickerTable.Value;
     public DefaultItemsTable DefaultItemsTable => defaultItemsTable.Value;
@@ -127,6 +129,8 @@ public class TableMetadataStorage {
 
     public DungeonRoomTable DungeonRoomTable => dungeonRoomTable.Value;
     public DungeonRankRewardTable DungeonRankRewardTable => dungeonRankRewardTable.Value;
+    public DungeonConfigTable DungeonConfigTable => dungeonConfigTable.Value;
+    public DungeonMissionTable DungeonMissionTable => dungeonMissionTable.Value;
 
     public TableMetadataStorage(MetadataContext context) {
         chatStickerTable = Retrieve<ChatStickerTable>(context, TableNames.CHAT_EMOTICON);
@@ -186,6 +190,8 @@ public class TableMetadataStorage {
         weaponVariationTable = Retrieve<ItemEquipVariationTable>(context, TableNames.ITEM_OPTION_VARIATION_WEAPON);
         dungeonRoomTable = Retrieve<DungeonRoomTable>(context, TableNames.DUNGEON_ROOM);
         dungeonRankRewardTable = Retrieve<DungeonRankRewardTable>(context, TableNames.DUNGEON_RANK_REWARD);
+        dungeonConfigTable = Retrieve<DungeonConfigTable>(context, TableNames.DUNGEON_CONFIG);
+        dungeonMissionTable = Retrieve<DungeonMissionTable>(context, TableNames.DUNGEON_MISSION);
     }
 
     private static Lazy<T> Retrieve<T>(MetadataContext context, string key) where T : Table {

--- a/Maple2.File.Ingest/Mapper/TableMapper.cs
+++ b/Maple2.File.Ingest/Mapper/TableMapper.cs
@@ -1666,7 +1666,6 @@ public class TableMapper : TypeMapper<TableMetadata> {
     private DungeonMissionTable ParseDungeonMissionTable() {
         var results = new Dictionary<int, DungeonMissionMetadata>();
         foreach ((int id, DungeonMission mission) in parser.ParseDungeonMission()) {
-            Console.WriteLine(id);
             if (!Enum.TryParse(mission.type, out DungeonMissionType type)) {
                 Console.WriteLine($"Unknown Mission type: {mission.type}");
                 continue;

--- a/Maple2.Model/Common/ServerTableNames.cs
+++ b/Maple2.Model/Common/ServerTableNames.cs
@@ -4,7 +4,7 @@ public static class ServerTableNames {
     public const string INSTANCE_FIELD = "instancefield.xml";
     public const string SCRIPT_CONDITION = "*scriptCondition.xml";
     public const string SCRIPT_FUNCTION = "*scriptFunction.xml";
-    public const string SCRIPT_EVENT = "sceiptEventCondition.xml";
+    public const string SCRIPT_EVENT = "scriptEventCondition.xml";
     public const string JOB_CONDITION = "jobConditionTable.xml";
     public const string BONUS_GAME = "bonusGame*.xml";
     public const string GLOBAL_DROP_ITEM_BOX = "globalItemDrop*.xml";

--- a/Maple2.Model/Common/ServerTableNames.cs
+++ b/Maple2.Model/Common/ServerTableNames.cs
@@ -4,6 +4,7 @@ public static class ServerTableNames {
     public const string INSTANCE_FIELD = "instancefield.xml";
     public const string SCRIPT_CONDITION = "*scriptCondition.xml";
     public const string SCRIPT_FUNCTION = "*scriptFunction.xml";
+    public const string SCRIPT_EVENT = "sceiptEventCondition.xml";
     public const string JOB_CONDITION = "jobConditionTable.xml";
     public const string BONUS_GAME = "bonusGame*.xml";
     public const string GLOBAL_DROP_ITEM_BOX = "globalItemDrop*.xml";
@@ -21,4 +22,5 @@ public static class ServerTableNames {
     public const string MERET_MARKET = "shop_merat_custom.xml";
     public const string FISH = "fish*.xml";
     public const string COMBINE_SPAWN = "combineSpawn*.xml";
+    public const string ENCHANT_OPTION = "enchantOption.xml";
 }

--- a/Maple2.Model/Common/TableNames.cs
+++ b/Maple2.Model/Common/TableNames.cs
@@ -72,6 +72,8 @@ public static class TableNames {
     // Dungeon
     public const string DUNGEON_ROOM = "dungeonroom.xml";
     public const string DUNGEON_RANK_REWARD = "dungeonrankreward.xml";
+    public const string DUNGEON_CONFIG = "dungeonconfig.xml";
+    public const string DUNGEON_MISSION = "dungeonmission.xml";
 
     public static readonly Dictionary<string, string> ItemOptionVariationTableNames = new Dictionary<string, string> {
         { "acc", ITEM_OPTION_VARIATION_ACC },

--- a/Maple2.Model/Enum/Dungeon.cs
+++ b/Maple2.Model/Enum/Dungeon.cs
@@ -54,8 +54,8 @@ public enum DungeonRequireRole {
 }
 
 public enum DungeonEnterLimit : byte {
-    Unknown = 0,
-    None = 1,
+    Rookie = 0,
+    Veteran = 1,
     MinLevel = 12,
     Achievement = 13,
     Vip = 14,
@@ -107,7 +107,7 @@ public enum DungeonState : byte {
     Fail = 2,
 }
 
-public enum DungeonGrade {
+public enum DungeonMissionRank {
     None = -1,
     F = 0,
     C = 1,
@@ -124,20 +124,42 @@ public enum DungeonRewardType : byte {
 }
 
 [Flags]
-public enum DungeonBonusFlag : byte {
-    None = 0,
-    Clears = 2,
+public enum DungeonBonusFlag {
+    None = 1,
+    [Description("s_dungeon_reward_dungeon_reward_count - Dungeon Clears: {0}")]
+    Clear = 2,
+    [Description("s_dungeon_reward_bonus_event - Event Bonus")]
     Event = 4,
-    Rank = 8,
+    [Description("s_dungeon_reward_mission_rank - Rank Bonus")]
+    MissionRank = 8,
+    [Description("s_dungeon_reward_dungeon_helper - Dungeon Helper Bonus")]
     Helper = 16,
+    [Description("s_dungeon_reward_dungeon_helper_event - Mutual Help Event")]
     MutualHelp = 32,
+    [Description("s_dungeon_reward_mentor - Mentor Bonus")]
     Mentor = 64,
-    Returning = 128,
+    [Description("s_dungeon_reward_mentee - Returning Player Bonus")]
+    Mentee = 128,
+    [Description("s_dungeon_reward_mentee_party_gift - Mentee Party Gift")]
+    MenteePartyGift = 256,
+    [Description("s_dungeon_reward_united_weekly - Weekly Bonus")]
+    UnitedWeekly = 512,
+}
+
+public enum DungeonMissionType {
+    LastHitNpc,
+    PlayTime,
+    DamageBySkill,
+    DeathCount,
+    GainBuff,
+    LimitUserCount,
+    Trigger,
+    DamageToNpc,
 }
 
 [Flags]
-public enum DungeonBonusFlag2 : byte {
+public enum DungeonRecordFlag : byte {
     None = 0,
-    ReturningPlayerParty = 1,
-    NormalHardAdventure = 2,
+    Veteran = 1,
+    Favorite = 2,
 }

--- a/Maple2.Model/Enum/EnchantResult.cs
+++ b/Maple2.Model/Enum/EnchantResult.cs
@@ -1,11 +1,22 @@
-﻿namespace Maple2.Model.Enum;
+﻿using System.ComponentModel;
+
+namespace Maple2.Model.Enum;
 
 // These could be flags but not sure
 public enum EnchantResult : byte {
     None = 0,
     Success = 1,
     Fail = 2,
-    Unknown3 = 3, // Considered failure as well
-    Destabilize = 4,
-    Unknown5 = 5, // Considered failture as well
+    LevelDown = 3,
+    FailDamage = 4,
+    FailWithProtect = 5,
+}
+
+public enum EnchantFailType : short {
+    [Description("s_enchant_fail_desc0 - ''")]
+    None = 0,
+    [Description("s_enchant_fail_desc1 - Failure will reduce this item's enchantment level.")]
+    LevelDown = 1,
+    [Description("s_enchant_fail_desc2 - Failure will render this item Unstable.\\nUnstable gear can no longer be enchanted.")]
+    Unstabilize = 2,
 }

--- a/Maple2.Model/Enum/EnchantScrollType.cs
+++ b/Maple2.Model/Enum/EnchantScrollType.cs
@@ -1,0 +1,9 @@
+﻿namespace Maple2.Model.Enum;
+
+public enum EnchantScrollType : short {
+    Enchant = 1,
+    Restore = 2,
+    Random = 3,
+    Rune = 4,
+    Stabilize = 5,
+}

--- a/Maple2.Model/Enum/EnchantType.cs
+++ b/Maple2.Model/Enum/EnchantType.cs
@@ -5,3 +5,9 @@ public enum EnchantType : byte {
     Ophelia = 1,
     Peachy = 2,
 }
+
+public enum EnchantDamageType {
+    None = 0,
+    Destable = 1,
+    Unstable = 2, // ??
+}

--- a/Maple2.Model/Enum/NpcTalk.cs
+++ b/Maple2.Model/Enum/NpcTalk.cs
@@ -117,6 +117,17 @@ public enum NpcTalkAction : byte {
     Cutscene = 10,
 }
 
-public enum NpcEventType : short {
-    Empower = 202,
+public enum ScriptEventType : short {
+    EnchantSelect = 1,
+    EnchantFail = 2,
+    EnchantComplete = 3,
+    PeachySelect = 31,
+    RerollItemSelect = 100,
+    RerollFail = 101,
+    RerollOptionSelect = 102,
+    RerollComplete = 103,
+    EmpowerSelect = 202,
+    EmpowerTry = 203,
+    EmpowerResult = 204,
+
 }

--- a/Maple2.Model/Error/ItemEnchantError.cs
+++ b/Maple2.Model/Error/ItemEnchantError.cs
@@ -13,4 +13,8 @@ public enum ItemEnchantError : short {
     s_itemenchant_damaged_item = 2,
     [Description("Not enough materials.")]
     s_itemenchant_lack_ingredient = 3,
+    not_enough_fodder = 4,
+    excess_fodder = 5,
+    max_fodder = 6,
+    over_100_success_rate = 7,
 }

--- a/Maple2.Model/Game/Dungeon/DungeonMission.cs
+++ b/Maple2.Model/Game/Dungeon/DungeonMission.cs
@@ -1,0 +1,35 @@
+﻿using Maple2.Model.Enum;
+using Maple2.Model.Metadata;
+using Maple2.PacketLib.Tools;
+using Maple2.Tools;
+
+namespace Maple2.Model.Game.Dungeon;
+
+public class DungeonMission : IByteSerializable {
+    public readonly DungeonMissionMetadata Metadata;
+    public int Id => Metadata.Id;
+    public short Score { get; private set; }
+    public short Counter { get; private set; }
+
+    public bool Update(int counter = 1) {
+        if (Counter >= Metadata.ApplyCount) {
+            return false;
+        }
+
+        Counter += (short) counter;
+        float percentage = (float) Counter / Metadata.ApplyCount;
+        Score = (short) (percentage * Metadata.MaxScore);
+        return true;
+    }
+
+    public void Complete() {
+        Counter = Metadata.ApplyCount;
+        Score = Metadata.MaxScore;
+    }
+
+    public void WriteTo(IByteWriter writer) {
+        writer.WriteInt(Id);
+        writer.WriteShort(Score);
+        writer.WriteShort(Counter);
+    }
+}

--- a/Maple2.Model/Game/Dungeon/DungeonRecord.cs
+++ b/Maple2.Model/Game/Dungeon/DungeonRecord.cs
@@ -29,7 +29,7 @@ public class DungeonRecord : IByteSerializable {
         writer.WriteInt(DungeonId);
         writer.WriteLong(UnionCooldownTimestamp);
         writer.WriteByte(UnionClears);
-        writer.WriteByte(UnionClears);
+        writer.WriteByte(UnionSubClears);
         writer.WriteLong(UnionSubCooldownTimestamp);
         writer.WriteByte(ExtraSubClears);
         writer.WriteByte(ExtraClears);

--- a/Maple2.Model/Game/Dungeon/DungeonRecord.cs
+++ b/Maple2.Model/Game/Dungeon/DungeonRecord.cs
@@ -1,40 +1,43 @@
-﻿using Maple2.PacketLib.Tools;
+﻿using Maple2.Model.Enum;
+using Maple2.PacketLib.Tools;
 using Maple2.Tools;
 
 namespace Maple2.Model.Game.Dungeon;
 
 public class DungeonRecord : IByteSerializable {
     public readonly int DungeonId;
-    public byte DailyClears { get; set; }
-    public byte WeeklyClears { get; set; }
-    public long DailyResetTimestamp { get; set; }
-    public long WeeklyResetTimestamp { get; set; }
-    public long ClearTimestamp { get; init; }
-    public int TotalClears { get; init; }
+    public byte UnionSubClears { get; set; }
+    public byte UnionClears { get; set; }
+    public long UnionSubCooldownTimestamp { get; set; }
+    public long UnionCooldownTimestamp { get; set; }
+    public long CooldownTimestamp { get; set; }
+    public long ClearTimestamp { get; set; }
+    public int TotalClears { get; set; }
     public short LifetimeRecord { get; set; }
-    public short WeeklyRecord { get; set; }
-    public byte ExtraDailyClears { get; set; }
-    public byte ExtraWeeklyClears { get; set; }
+    public short CurrentRecord { get; set; }
+    public byte ExtraSubClears { get; set; }
+    public byte ExtraClears { get; set; }
+    public DungeonRecordFlag Flag { get; set; }
 
     public DungeonRecord(int dungeonId) {
         DungeonId = dungeonId;
         LifetimeRecord = -1;
-        WeeklyRecord = -1;
+        CurrentRecord = -1;
     }
 
     public void WriteTo(IByteWriter writer) {
         writer.WriteInt(DungeonId);
-        writer.WriteLong(WeeklyResetTimestamp);
-        writer.WriteByte(WeeklyClears);
-        writer.WriteByte(DailyClears);
-        writer.WriteLong(DailyResetTimestamp);
-        writer.WriteByte(ExtraDailyClears);
-        writer.WriteByte(ExtraWeeklyClears);
+        writer.WriteLong(UnionCooldownTimestamp);
+        writer.WriteByte(UnionClears);
+        writer.WriteByte(UnionClears);
+        writer.WriteLong(UnionSubCooldownTimestamp);
+        writer.WriteByte(ExtraSubClears);
+        writer.WriteByte(ExtraClears);
         writer.WriteLong(ClearTimestamp);
         writer.WriteInt(TotalClears);
         writer.WriteShort(LifetimeRecord);
-        writer.WriteLong(WeeklyResetTimestamp); // Reusing it here.
-        writer.WriteShort(WeeklyClears);
-        writer.WriteByte();
+        writer.WriteLong(CooldownTimestamp);
+        writer.WriteShort(CurrentRecord);
+        writer.Write<DungeonRecordFlag>(Flag);
     }
 }

--- a/Maple2.Model/Game/Dungeon/DungeonRoomRecord.cs
+++ b/Maple2.Model/Game/Dungeon/DungeonRoomRecord.cs
@@ -6,12 +6,12 @@ namespace Maple2.Model.Game.Dungeon;
 
 public class DungeonRoomRecord {
     public ConcurrentDictionary<long, DungeonUserRecord> UserResults = [];
-    public readonly DungeonRoomTable.DungeonRoomMetadata Metadata;
+    public readonly DungeonRoomMetadata Metadata;
     public long StartTick { get; set; }
     public long EndTick { get; set; }
     public DungeonState State { get; set; } = DungeonState.None;
 
-    public DungeonRoomRecord(DungeonRoomTable.DungeonRoomMetadata metadata) {
+    public DungeonRoomRecord(DungeonRoomMetadata metadata) {
         Metadata = metadata;
     }
 }

--- a/Maple2.Model/Game/Dungeon/DungeonUserResult.cs
+++ b/Maple2.Model/Game/Dungeon/DungeonUserResult.cs
@@ -8,7 +8,7 @@ public struct DungeonUserResult {
     public readonly long CharacterId;
     public readonly DungeonAccumulationRecordType RecordType;
     public readonly int Value;
-    public DungeonGrade Grade = DungeonGrade.None;
+    public DungeonMissionRank MissionRank = DungeonMissionRank.None;
 
     public DungeonUserResult(long characterId, DungeonAccumulationRecordType recordType, int value) {
         CharacterId = characterId;

--- a/Maple2.Model/Game/Item/ItemEnchant.cs
+++ b/Maple2.Model/Game/Item/ItemEnchant.cs
@@ -35,9 +35,9 @@ public sealed class ItemEnchant : IByteSerializable, IByteDeserializable {
         writer.WriteInt(Enchants);
         writer.WriteInt(EnchantExp);
         writer.WriteByte(EnchantCharges);
-        writer.WriteLong();
+        writer.WriteLong(); // Destabilized timestamp
         writer.WriteInt();
-        writer.WriteInt();
+        writer.WriteInt();// Enchantment attempts
         writer.WriteBool(Tradeable);
         writer.WriteInt(Charges);
 

--- a/Maple2.Model/Metadata/Constants.cs
+++ b/Maple2.Model/Metadata/Constants.cs
@@ -97,6 +97,8 @@ public static class Constant {
     public const int GuildCoinRarity = 4;
     public const int BlueprintId = 35200000;
     public const int EmpowermentNpc = 11003416;
+    public const int OpheliaNpc = 11000508;
+    public const int PeachyNpc = 11000510;
     public const int InteriorPortalCubeId = 50400158;
     public const int PortalEntryId = 50400190;
     public const int Grade1WeddingCouponItemId = 20303166;
@@ -114,8 +116,27 @@ public static class Constant {
     public static IReadOnlyDictionary<string, int> ContentRewards { get; } = new Dictionary<string, int> {
         {"miniGame", 1005},
         {"dungeonHelper", 1006},
-        {"MiniGameType2", 0}, // Shanghai Runners
-        {"UserOpenMiniGameExtraReward", 0}, // Player hosted mini game extra rewards
+        {"MiniGameType2",1007}, // Shanghai Runners
+        {"UserOpenMiniGameExtraReward", 1008}, // Player hosted mini game extra rewards
+        {"PrestigeRankUp", 1020},
+        {"NormalHardDungeonBonusTier1", 10000001},
+        {"NormalHardDungeonBonusTier2", 10000002},
+        {"NormalHardDungeonBonusTier3", 10000003},
+        {"NormalHardDungeonBonusTier4", 10000004},
+        {"NormalHardDungeonBonusTier5", 10000005},
+        {"NormalHardDungeonBonusTier6", 10000006},
+        {"NormalHardDungeonBonusTier7", 10000007},
+        {"NormalHardDungeonBonusTier8", 10000008},
+        {"QueenBeanArenaRound1Reward", 10000009},
+        {"QueenBeanArenaRound2Reward", 10000010},
+        {"QueenBeanArenaRound3Reward", 10000011},
+        {"QueenBeanArenaRound4Reward", 10000012},
+        {"QueenBeanArenaRound5Reward", 10000013},
+        {"QueenBeanArenaRound6Reward", 10000014},
+        {"QueenBeanArenaRound7Reward", 10000015},
+        {"QueenBeanArenaRound8Reward", 10000016},
+        {"QueenBeanArenaRound9Reward", 10000017},
+        {"QueenBeanArenaRound10Reward", 10000018},
     };
 
     public const bool MailQuestItems = false; // Mail quest item rewards if inventory is full

--- a/Maple2.Model/Metadata/ServerTable/EnchantOptionTable.cs
+++ b/Maple2.Model/Metadata/ServerTable/EnchantOptionTable.cs
@@ -1,0 +1,15 @@
+﻿using Maple2.Model.Enum;
+
+namespace Maple2.Model.Metadata;
+
+public record EnchantOptionTable(IReadOnlyDictionary<int, EnchantOptionMetadata> Entries) : ServerTable;
+
+public record EnchantOptionMetadata(
+    int Id,
+    int Slot,
+    int EnchantLevel,
+    short Rarity,
+    float Rate,
+    int MinLevel,
+    int MaxLevel,
+    BasicAttribute[] Attributes);

--- a/Maple2.Model/Metadata/ServerTable/ScriptEventConditionTable.cs
+++ b/Maple2.Model/Metadata/ServerTable/ScriptEventConditionTable.cs
@@ -1,0 +1,17 @@
+﻿using Maple2.Model.Enum;
+using Maple2.Model.Error;
+
+namespace Maple2.Model.Metadata;
+
+public record ScriptEventConditionTable(IReadOnlyDictionary<ScriptEventType, Dictionary<int, ScriptEventConditionMetadata>> Entries) : ServerTable;
+
+public record ScriptEventConditionMetadata(
+    int Id,
+    ScriptEventType EventType,
+    ItemEnchantError ErrorCode,
+    short Rarity,
+    int[] EnchantLevel,
+    int FailCount,
+    EnchantDamageType DamageType,
+    EnchantResult ResultType
+    );

--- a/Maple2.Model/Metadata/ServerTableMetadata.cs
+++ b/Maple2.Model/Metadata/ServerTableMetadata.cs
@@ -28,6 +28,7 @@ public class ServerTableMetadata {
 [JsonDerivedType(typeof(InstanceFieldTable), typeDiscriminator: "instancefield")]
 [JsonDerivedType(typeof(ScriptConditionTable), typeDiscriminator: "*scriptCondition")]
 [JsonDerivedType(typeof(ScriptFunctionTable), typeDiscriminator: "*scriptFunction")]
+[JsonDerivedType(typeof(ScriptEventConditionTable), typeDiscriminator: "*scriptEventCondition")]
 [JsonDerivedType(typeof(JobConditionTable), typeDiscriminator: "jobConditionTable")]
 [JsonDerivedType(typeof(BonusGameTable), typeDiscriminator: "bonusGame")]
 [JsonDerivedType(typeof(GlobalDropItemBoxTable), typeDiscriminator: "globalItemDrop")]
@@ -45,4 +46,5 @@ public class ServerTableMetadata {
 [JsonDerivedType(typeof(MeretMarketTable), typeDiscriminator: "meretMarket")]
 [JsonDerivedType(typeof(FishTable), typeDiscriminator: "fish")]
 [JsonDerivedType(typeof(CombineSpawnTable), typeDiscriminator: "combineSpawn")]
+[JsonDerivedType(typeof(EnchantOptionTable), typeDiscriminator: "enchantOption")]
 public abstract record ServerTable;

--- a/Maple2.Model/Metadata/Table/DungeomRoomTable.cs
+++ b/Maple2.Model/Metadata/Table/DungeomRoomTable.cs
@@ -2,32 +2,33 @@
 
 namespace Maple2.Model.Metadata;
 
-public record DungeonRoomTable(IReadOnlyDictionary<int, DungeonRoomTable.DungeonRoomMetadata> Entries) : Table {
-    public record DungeonRoomMetadata(
-        int Id,
-        short Level,
-        DungeonPlayType PlayType,
-        DungeonGroupType GroupType,
-        DungeonCooldownType CooldownType,
-        int CooldownValue,
-        int DurationTick,
-        int LobbyFieldId,
-        int[] FieldIds,
-        DungeonRoomReward Reward,
-        DungeonRoomLimit Limit,
-        int PlayerCountFactorId,
-        short CustomMonsterLevel,
-        int HelperRequireClearCount,
-        bool DisabledFindHelper,
-        int RankTableId,
-        bool LeaveAfterCloseReward,
-        int[] PartyMissions,
-        int[] UserMissions,
-        bool MoveToBackupField
-        );
-}
+public record DungeonRoomTable(IReadOnlyDictionary<int, DungeonRoomMetadata> Entries) : Table;
 
-public record DungeonRoomReward(
+public record DungeonRoomMetadata(
+    int Id,
+    short Level,
+    DungeonPlayType PlayType,
+    DungeonGroupType GroupType,
+    DungeonCooldownType CooldownType,
+    int CooldownValue,
+    int DurationTick,
+    int LobbyFieldId,
+    int[] FieldIds,
+    DungeonRoomRewardMetadata Reward,
+    DungeonRoomLimitMetadata Limit,
+    int PlayerCountFactorId,
+    short CustomMonsterLevel,
+    int HelperRequireClearCount,
+    bool DisabledFindHelper,
+    int RankTableId,
+    int RoundId,
+    bool LeaveAfterCloseReward,
+    int[] PartyMissions,
+    int[] UserMissions,
+    bool MoveToBackupField
+);
+
+public record DungeonRoomRewardMetadata(
     bool AccountWide,
     int Count,
     int SubRewardCount,
@@ -41,7 +42,7 @@ public record DungeonRoomReward(
     int ScoreBonusId
 );
 
-public record DungeonRoomLimit(
+public record DungeonRoomLimitMetadata(
     int MinUserCount,
     int MaxUserCount,
     int GearScore,

--- a/Maple2.Model/Metadata/Table/DungeonConfigTable.cs
+++ b/Maple2.Model/Metadata/Table/DungeonConfigTable.cs
@@ -2,7 +2,8 @@
 
 namespace Maple2.Model.Metadata;
 
-public record DungeonConfigTable(IReadOnlyDictionary<int, int> UnitedWeeklyRewards, // Key: RewardCount, Value: RewardId
+public record DungeonConfigTable(
+    IReadOnlyDictionary<int, int> UnitedWeeklyRewards, // Key: RewardCount, Value: RewardId
     IReadOnlyDictionary<int, DungeonMissionRankMetadata> MissionRanks) : Table;
 
 public record DungeonMissionRankMetadata(
@@ -13,5 +14,4 @@ public record DungeonMissionRankMetadata(
     public record Score(
         DungeonMissionRank Grade,
         int Value);
-    }
-
+}

--- a/Maple2.Model/Metadata/Table/DungeonConfigTable.cs
+++ b/Maple2.Model/Metadata/Table/DungeonConfigTable.cs
@@ -1,0 +1,17 @@
+﻿using Maple2.Model.Enum;
+
+namespace Maple2.Model.Metadata;
+
+public record DungeonConfigTable(IReadOnlyDictionary<int, int> UnitedWeeklyRewards, // Key: RewardCount, Value: RewardId
+    IReadOnlyDictionary<int, DungeonMissionRankMetadata> MissionRanks) : Table;
+
+public record DungeonMissionRankMetadata(
+    int Id,
+    string Description,
+    int MaxScore,
+    DungeonMissionRankMetadata.Score[] Scores) {
+    public record Score(
+        DungeonMissionRank Grade,
+        int Value);
+    }
+

--- a/Maple2.Model/Metadata/Table/DungeonMissionTable.cs
+++ b/Maple2.Model/Metadata/Table/DungeonMissionTable.cs
@@ -1,0 +1,16 @@
+﻿using Maple2.Model.Enum;
+
+namespace Maple2.Model.Metadata;
+
+public record DungeonMissionTable(IReadOnlyDictionary<int, DungeonMissionMetadata> Missions) : Table;
+
+public record DungeonMissionMetadata(
+    int Id,
+    DungeonMissionType Type,
+    long[] Value1, // Technically this is a float in the xml but the difference is negligible/impossible.
+    long Value2,
+    short MaxScore,
+    short ApplyCount,
+    bool IsPenaltyType);
+
+

--- a/Maple2.Model/Metadata/Table/ScrollTable.cs
+++ b/Maple2.Model/Metadata/Table/ScrollTable.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Maple2.Model.Enum;
 using Maple2.Model.Game;
 
 namespace Maple2.Model.Metadata;
@@ -6,7 +7,7 @@ namespace Maple2.Model.Metadata;
 public record EnchantScrollTable(IReadOnlyDictionary<int, EnchantScrollMetadata> Entries) : Table;
 
 public record EnchantScrollMetadata(
-    short Type,
+    EnchantScrollType Type,
     short MinLevel,
     short MaxLevel,
     int[] Enchants,

--- a/Maple2.Model/Metadata/TableMetadata.cs
+++ b/Maple2.Model/Metadata/TableMetadata.cs
@@ -79,5 +79,7 @@ public class TableMetadata {
 [JsonDerivedType(typeof(UgcHousingPointRewardTable), typeDiscriminator: "ugchousingpointreward")]
 [JsonDerivedType(typeof(DungeonRoomTable), typeDiscriminator: "dungeonroom")]
 [JsonDerivedType(typeof(DungeonRankRewardTable), typeDiscriminator: "dungeonrankreward")]
+[JsonDerivedType(typeof(DungeonConfigTable), typeDiscriminator: "dungeonconfig")]
+[JsonDerivedType(typeof(DungeonMissionTable), typeDiscriminator: "dungeonmission")]
 [JsonDerivedType(typeof(RewardContentTable), typeDiscriminator: "rewardcontent")]
 public abstract record Table;

--- a/Maple2.Server.Core/Formulas/Enchant.cs
+++ b/Maple2.Server.Core/Formulas/Enchant.cs
@@ -1,0 +1,202 @@
+﻿using Maple2.Model.Enum;
+using Maple2.Model.Game;
+
+namespace Maple2.Server.Core.Formulas;
+
+public static class Enchant {
+    private static float[] LV_50_ENCHANT_ONYX_MULTIPLIER = [1, 1, 1, 1.37106f, 1.37106f, 1.742f, 2.1116f, 2.482f, 2.853f, 3.25f, 3.718f, 3.718f, 3.718f, 3.718f, 3.718f];
+    private static float[] LV_70_ENCHANT_ONYX_MULTIPLIER = [1, 1, 1, 1.37106f, 1.37106f, 1.742f, 2.1116f, 2.482f, 2.853f, 5.707f, 5.707f, 8.561f, 8.561f, 11.415f, 11.415f];
+    private static float[] ONYX_RARITY_MULTIPLIER = [0, 1, 1.237f, 1.5548f, 1.9216f, 2.3115f, 2.7794f];
+
+    private static float[] LV_50_ENCHANT_CRYSTAL_FRAGMENT_MULTIPLIER = [1, 1, 1, 1.4f, 1.4f, 1.7f, 2.1f, 2.5f, 2.9f, 3.2f, 3.7f, 3.7f, 3.7f, 3.7f, 3.7f];
+    private static float[] LV_70_ENCHANT_CRYSTAL_FRAGMENT_MULTIPLIER = [1, 1, 1, 1.375f, 1.375f, 1.75f, 2.125f, 2.4375f, 2.8125f, 7.5f, 7.5f, 11.25f, 11.25f, 15f, 15f];
+    private static float[] CRYSTAL_FRAGMENT_RARITY_MULTIPLIER = [0, 1, 1.1897f, 1.49482f, 1.9216f, 2.4f, 3];
+
+    private static float[] LV_50_ENCHANT_CHAOS_ONYX_MULTIPLIER = [1, 1, 1, 1.37106f, 1.37106f, 1.742f, 2.1116f, 2.482f, 2.853f, 3.25f, 3.718f, 3.718f, 3.718f, 3.718f, 3.718f];
+    private static float[] LV_70_ENCHANT_CHAOS_ONYX_MULTIPLIER = [1, 1, 1, 1.333f, 1.333f, 2.25f, 2.25f, 2.25f, 2.25f, 8f, 8f, 12f, 12f, 16f, 16f];
+    private static float[] CHAOS_ONYX_RARITY_MULTIPLIER = [0, 0, 1.237f, 1.5548f, 1.9216f, 2.3115f, 2.7794f];
+
+    public static List<IngredientInfo> GetEnchantCost(Item item) {
+        List<IngredientInfo> costs = [];
+        IngredientInfo onyx = GetOnyxCost(item);
+        if (onyx.Amount > 0) {
+            costs.Add(onyx);
+        }
+        IngredientInfo chaosOnyx = GetChaosOnyxCost(item);
+        if (chaosOnyx.Amount > 0) {
+            costs.Add(chaosOnyx);
+        }
+        IngredientInfo crystalFragment = GetCrystalFragmentCost(item);
+        if (crystalFragment.Amount > 0) {
+            costs.Add(crystalFragment);
+        }
+
+        return costs;
+    }
+    private static IngredientInfo GetOnyxCost(Item item) {
+        int itemLevel = item.Metadata.Limit.Level;
+        double cost = 0;
+        if (itemLevel is >= 20 and <= 50) {
+            cost = 0.00011614 * Math.Pow(itemLevel, 4)
+                   - 0.01078 * Math.Pow(itemLevel, 3)
+                   + 0.46993 * Math.Pow(itemLevel, 2)
+                   - 8.19353 * itemLevel
+                   + 64.48147;
+            cost = cost * ONYX_RARITY_MULTIPLIER[item.Rarity];
+            cost = Math.Max(1, Math.Floor(cost));
+        } else {
+            switch (item.Rarity) {
+                case 1:
+                case 2:
+                case 3:
+                    // not supported?
+                    break;
+                case 4:
+                    cost = 636;
+                    break;
+                case 5:
+                    if (itemLevel < 70) {
+                        cost = (507.0 / 14.0) * (itemLevel - 56) + 765;
+                        break;
+                    }
+                    cost = 1272;
+                    break;
+                case 6:
+                    cost = 1908; // may not be accurate but this is all the data I have
+                    break;
+            }
+        }
+
+        cost = ItemTypeMultiplier(item.Type, cost);
+
+        int enchantLevel = item.Enchant?.Enchants ?? 0;
+        if (itemLevel <= 50) {
+            cost *= LV_50_ENCHANT_ONYX_MULTIPLIER[enchantLevel];
+        } else {
+            cost *= LV_70_ENCHANT_ONYX_MULTIPLIER[enchantLevel];
+        }
+
+        return new IngredientInfo(ItemTag.Onix, (int) Math.Round(cost));
+    }
+
+    private static IngredientInfo GetCrystalFragmentCost(Item item) {
+        int itemLevel = item.Metadata.Limit.Level;
+        double cost = 0;
+        if (itemLevel is >= 20 and <= 50) {
+            cost = -0.0000049627 * Math.Pow(itemLevel, 4)
+                          +  0.0006886    * Math.Pow(itemLevel, 3)
+                          -  0.0285752    * Math.Pow(itemLevel, 2)
+                          +  0.45096      * itemLevel
+                          -  1.2688;
+
+            cost = cost * CRYSTAL_FRAGMENT_RARITY_MULTIPLIER[item.Rarity];
+            cost = Math.Max(1, Math.Floor(cost));
+        } else {
+            switch (item.Rarity) {
+                case 1:
+                case 2:
+                case 3:
+                    // not supported?
+                    break;
+                case 4:
+                    cost = 16;
+                    break;
+                case 5:
+                    if (itemLevel < 70) {
+                        cost = 19;
+                        break;
+                    }
+                    cost = 96;
+                    break;
+                case 6:
+                    if (itemLevel < 70) {
+                        cost = 24;
+                        break;
+                    }
+                    cost = 144;
+                    break;
+            }
+        }
+
+        cost = ItemTypeMultiplier(item.Type, cost);
+        int enchantLevel = item.Enchant?.Enchants ?? 0;
+        if (itemLevel <= 50) {
+            cost *= LV_50_ENCHANT_CRYSTAL_FRAGMENT_MULTIPLIER[enchantLevel];
+        } else {
+            cost *= LV_70_ENCHANT_CRYSTAL_FRAGMENT_MULTIPLIER[enchantLevel];
+        }
+
+
+        return new IngredientInfo(ItemTag.CrystalPiece, (int) cost);
+    }
+
+    private static IngredientInfo GetChaosOnyxCost(Item item) {
+        int itemLevel = item.Metadata.Limit.Level;
+        double cost = 0;
+        if (itemLevel is >= 20 and <= 50) {
+           cost = -0.001023 * Math.Pow(itemLevel, 2)
+                +  0.11095  * itemLevel
+                -  0.91968;
+
+           cost = cost * CHAOS_ONYX_RARITY_MULTIPLIER[item.Rarity];
+           cost = Math.Floor(cost);
+        } else {
+            switch (item.Rarity) {
+                case 1:
+                case 2:
+                case 3:
+                    break;
+                case 4:
+                    cost = 2;
+                    break;
+                case 5:
+                    cost = (3.0 / 7.0) * (itemLevel - 56) + 2;
+                    break;
+                case 6:
+                    cost = 12;
+                    break;
+            }
+        }
+
+        cost = ItemTypeMultiplier(item.Type, cost);
+        int enchantLevel = item.Enchant?.Enchants ?? 0;
+        if (itemLevel <= 50) {
+            cost *= LV_50_ENCHANT_CHAOS_ONYX_MULTIPLIER[enchantLevel];
+        } else {
+            cost *= LV_70_ENCHANT_CHAOS_ONYX_MULTIPLIER[enchantLevel];
+        }
+
+        return new IngredientInfo(ItemTag.ChaosOnix, (int) cost);
+    }
+
+    private static double ItemTypeMultiplier(ItemType itemType, double cost) {
+        //  Two hand weapon/ main hand weapon
+        if (itemType.IsBludgeon ||
+            itemType.IsLongsword ||
+            itemType.IsGreatsword ||
+            itemType.IsStaff ||
+            itemType.IsScepter ||
+            itemType.IsBow ||
+            itemType.IsCannon ||
+            itemType.IsBlade ||
+            itemType.IsKnuckle ||
+            itemType.IsOrb) {
+            cost *= 2;
+        } else if (itemType.IsDagger ||
+                   itemType.IsThrowingStar) {
+            cost *= 1;
+        } else if (itemType.IsClothes ||
+                   itemType.IsPants) {
+            cost *= 1;
+        } else if (itemType.IsOverall) {
+            cost *= 2;
+        } else if (itemType.IsGloves ||
+                   itemType.IsShoes) {
+            cost *= 0.1792;
+        } else if (itemType.IsHat) {
+            cost *= 0.66;
+        }
+
+        return cost;
+    }
+}

--- a/Maple2.Server.Core/Formulas/Enchant.cs
+++ b/Maple2.Server.Core/Formulas/Enchant.cs
@@ -84,10 +84,10 @@ public static class Enchant {
         double cost = 0;
         if (itemLevel is >= 20 and <= 50) {
             cost = -0.0000049627 * Math.Pow(itemLevel, 4)
-                          +  0.0006886    * Math.Pow(itemLevel, 3)
-                          -  0.0285752    * Math.Pow(itemLevel, 2)
-                          +  0.45096      * itemLevel
-                          -  1.2688;
+                   + 0.0006886 * Math.Pow(itemLevel, 3)
+                   - 0.0285752 * Math.Pow(itemLevel, 2)
+                   + 0.45096 * itemLevel
+                   - 1.2688;
 
             cost = cost * CRYSTAL_FRAGMENT_RARITY_MULTIPLIER[item.Rarity];
             cost = Math.Max(1, Math.Floor(cost));
@@ -134,12 +134,12 @@ public static class Enchant {
         int itemLevel = item.Metadata.Limit.Level;
         double cost = 0;
         if (itemLevel is >= 20 and <= 50) {
-           cost = -0.001023 * Math.Pow(itemLevel, 2)
-                +  0.11095  * itemLevel
-                -  0.91968;
+            cost = -0.001023 * Math.Pow(itemLevel, 2)
+                   + 0.11095 * itemLevel
+                   - 0.91968;
 
-           cost = cost * CHAOS_ONYX_RARITY_MULTIPLIER[item.Rarity];
-           cost = Math.Floor(cost);
+            cost = cost * CHAOS_ONYX_RARITY_MULTIPLIER[item.Rarity];
+            cost = Math.Floor(cost);
         } else {
             switch (item.Rarity) {
                 case 1:

--- a/Maple2.Server.Game/GameServer.cs
+++ b/Maple2.Server.Game/GameServer.cs
@@ -102,7 +102,7 @@ public class GameServer : Server<GameSession> {
         return fieldFactory.Get(mapId, roomId: roomId);
     }
 
-    public DungeonFieldManager? CreateDungeon(DungeonRoomTable.DungeonRoomMetadata metadata, long requesterId, int size, int partyId) {
+    public DungeonFieldManager? CreateDungeon(DungeonRoomMetadata metadata, long requesterId, int size, int partyId) {
         return fieldFactory.CreateDungeon(metadata, requesterId, size, partyId);
     }
 

--- a/Maple2.Server.Game/Manager/DungeonManager.cs
+++ b/Maple2.Server.Game/Manager/DungeonManager.cs
@@ -77,6 +77,7 @@ public class DungeonManager {
         if (session.Field.FieldInstance.Type == InstanceType.DungeonLobby) {
             session.Send(DungeonWaitingPacket.Set(Lobby.DungeonId, Lobby.Size));
         } else {
+            // DEBUG
             /*session.Send(RoomStageDungeonPacket.Set(Metadata.Id));
             ByteWriter pWriter = Packet.Of(SendOp.DungeonMission);
             pWriter.WriteByte(0);
@@ -229,7 +230,7 @@ public class DungeonManager {
         UserRecord = new DungeonUserRecord(field.DungeonId, session.CharacterId);
 
         foreach (int missionId in Metadata.UserMissions) {
-
+            //TODO
         }
 
         field.DungeonRoomRecord.UserResults.TryAdd(session.CharacterId, UserRecord);

--- a/Maple2.Server.Game/Manager/DungeonManager.cs
+++ b/Maple2.Server.Game/Manager/DungeonManager.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using Grpc.Core;
 using Maple2.Database.Extensions;
@@ -10,8 +9,6 @@ using Maple2.Model.Game;
 using Maple2.Model.Game.Dungeon;
 using Maple2.Model.Game.Party;
 using Maple2.Model.Metadata;
-using Maple2.PacketLib.Tools;
-using Maple2.Server.Core.Constants;
 using Maple2.Server.Core.Packets;
 using Maple2.Server.Game.Manager.Field;
 using Maple2.Server.Game.Packets;
@@ -19,7 +16,6 @@ using Maple2.Server.Game.Session;
 using Maple2.Server.World.Service;
 using Maple2.Tools.Extensions;
 using Serilog;
-using Serilog.Core;
 using MigrationType = Maple2.Server.World.Service.MigrationType;
 
 namespace Maple2.Server.Game.Manager;

--- a/Maple2.Server.Game/Manager/DungeonManager.cs
+++ b/Maple2.Server.Game/Manager/DungeonManager.cs
@@ -1,4 +1,4 @@
-using System.Net;
+﻿using System.Net;
 using Grpc.Core;
 using Maple2.Database.Extensions;
 using Maple2.Database.Storage;

--- a/Maple2.Server.Game/Manager/DungeonManager.cs
+++ b/Maple2.Server.Game/Manager/DungeonManager.cs
@@ -1,5 +1,7 @@
-﻿using System.Net;
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
 using Grpc.Core;
+using Maple2.Database.Extensions;
 using Maple2.Database.Storage;
 using Maple2.Model;
 using Maple2.Model.Enum;
@@ -8,12 +10,16 @@ using Maple2.Model.Game;
 using Maple2.Model.Game.Dungeon;
 using Maple2.Model.Game.Party;
 using Maple2.Model.Metadata;
+using Maple2.PacketLib.Tools;
+using Maple2.Server.Core.Constants;
 using Maple2.Server.Core.Packets;
 using Maple2.Server.Game.Manager.Field;
 using Maple2.Server.Game.Packets;
 using Maple2.Server.Game.Session;
 using Maple2.Server.World.Service;
+using Maple2.Tools.Extensions;
 using Serilog;
+using Serilog.Core;
 using MigrationType = Maple2.Server.World.Service.MigrationType;
 
 namespace Maple2.Server.Game.Manager;
@@ -26,7 +32,7 @@ public class DungeonManager {
     private IDictionary<int, DungeonRankReward> RankRewards => session.Player.Value.Unlock.DungeonRankRewards;
 
     public DungeonFieldManager? Lobby { get; private set; }
-    public DungeonRoomTable.DungeonRoomMetadata? Metadata;
+    public DungeonRoomMetadata? Metadata;
     public DungeonRoomRecord? DungeonRoomRecord => Lobby?.DungeonRoomRecord;
     public DungeonUserRecord? UserRecord;
     private int LobbyRoomId { get; set; }
@@ -45,7 +51,7 @@ public class DungeonManager {
         using GameStorage.Request db = session.GameStorage.Context();
         Records = db.GetDungeonRecords(session.CharacterId);
 
-        foreach (DungeonRoomTable.DungeonRoomMetadata metadata in session.TableMetadata.DungeonRoomTable.Entries.Values) {
+        foreach (DungeonRoomMetadata metadata in session.TableMetadata.DungeonRoomTable.Entries.Values) {
             if (!Records.TryGetValue(metadata.Id, out DungeonRecord? record)) {
                 record = new DungeonRecord(metadata.Id);
                 record = db.CreateDungeonRecord(record, session.CharacterId);
@@ -56,7 +62,7 @@ public class DungeonManager {
                 Records.Add(metadata.Id, record);
             }
 
-            DungeonEnterLimit limit = GetEnterLimit(metadata.Limit);
+            DungeonEnterLimit limit = GetEnterLimit(metadata);
             EnterLimits[metadata.Id] = limit;
         }
     }
@@ -68,23 +74,32 @@ public class DungeonManager {
     }
 
     public void LoadField() {
-        if (Lobby == null) {
+        if (Lobby == null || session.Field is not DungeonFieldManager) {
             return;
         }
 
         if (session.Field.FieldInstance.Type == InstanceType.DungeonLobby) {
             session.Send(DungeonWaitingPacket.Set(Lobby.DungeonId, Lobby.Size));
+        } else {
+            session.Send(RoomStageDungeonPacket.Set(Metadata.Id));
+            ByteWriter pWriter = Packet.Of(SendOp.DungeonMission);
+            pWriter.WriteByte(0);
+            pWriter.WriteInt(1);
+            pWriter.WriteInt(23023005);
+            pWriter.WriteShort(1);
+            pWriter.WriteShort(); // counter
+            session.Send(pWriter);
         }
     }
 
     public void UpdateDungeonEnterLimit() {
         bool updated = false;
         foreach (int dungeonId in EnterLimits.Keys) {
-            if (!session.TableMetadata.DungeonRoomTable.Entries.TryGetValue(dungeonId, out DungeonRoomTable.DungeonRoomMetadata? metadata)) {
+            if (!session.TableMetadata.DungeonRoomTable.Entries.TryGetValue(dungeonId, out DungeonRoomMetadata? metadata)) {
                 continue;
             }
 
-            DungeonEnterLimit newLimit = GetEnterLimit(metadata.Limit);
+            DungeonEnterLimit newLimit = GetEnterLimit(metadata);
             if (EnterLimits[dungeonId] != newLimit) {
                 EnterLimits[dungeonId] = newLimit;
                 updated = true;
@@ -105,37 +120,39 @@ public class DungeonManager {
         }
     }
 
-    private DungeonEnterLimit GetEnterLimit(DungeonRoomLimit metadata) {
-        if (metadata.MinLevel > session.Player.Value.Character.Level) {
+    private DungeonEnterLimit GetEnterLimit(DungeonRoomMetadata metadata) {
+        DungeonRoomLimitMetadata limitMetadataMetadata = metadata.Limit;
+        if (limitMetadataMetadata.MinLevel > session.Player.Value.Character.Level) {
             return DungeonEnterLimit.MinLevel;
         }
 
-        if (metadata.RequiredAchievementId > 0 && !session.Achievement.HasAchievement(metadata.RequiredAchievementId)) {
+        if (limitMetadataMetadata.RequiredAchievementId > 0 && !session.Achievement.HasAchievement(limitMetadataMetadata.RequiredAchievementId)) {
             return DungeonEnterLimit.Achievement;
         }
 
-        if (metadata.VipOnly && !session.Config.IsPremiumClubActive()) {
+        if (limitMetadataMetadata.VipOnly && !session.Config.IsPremiumClubActive()) {
             return DungeonEnterLimit.Vip;
         }
 
-        if (metadata.GearScore > 0 && session.Stats.Values.GearScore < metadata.GearScore) {
+        if (limitMetadataMetadata.GearScore > 0 && session.Stats.Values.GearScore < limitMetadataMetadata.GearScore) {
             return DungeonEnterLimit.Gearscore;
         }
 
-        if (metadata.ClearDungeonIds.Length > 0) {
-            foreach (int dungeonId in metadata.ClearDungeonIds) {
-                if (!Records.TryGetValue(dungeonId, out DungeonRecord? record) || record.ClearTimestamp == 0) {
+        if (limitMetadataMetadata.ClearDungeonIds.Length > 0) {
+            foreach (int clearDungeonId in limitMetadataMetadata.ClearDungeonIds) {
+                DungeonRecord clearDungeonRecord = GetRecord(clearDungeonId);
+                if (clearDungeonRecord.ClearTimestamp == 0) {
                     return DungeonEnterLimit.DungeonClear;
                 }
             }
         }
 
-        if (metadata.Buffs.Length > 0 && metadata.Buffs.Any(buffId => !session.Buffs.HasBuff(buffId))) {
+        if (limitMetadataMetadata.Buffs.Length > 0 && limitMetadataMetadata.Buffs.Any(buffId => !session.Buffs.HasBuff(buffId))) {
             return DungeonEnterLimit.Buff;
         }
 
-        if (metadata.EquippedRecommendedWeapon) {
-            if (!session.Item.Equips.Gear.TryGetValue(EquipSlot.LH, out Item? item)) {
+        if (limitMetadataMetadata.EquippedRecommendedWeapon) {
+            if (!session.Item.Equips.Gear.TryGetValue(EquipSlot.RH, out Item? item)) {
                 return DungeonEnterLimit.RecommendedWeapon;
             }
             switch (session.Player.Value.Character.Job.Code()) {
@@ -201,7 +218,12 @@ public class DungeonManager {
                     break;
             }
         }
-        return DungeonEnterLimit.None;
+
+        if (GetRecord(metadata.Id).Flag.HasFlag(DungeonRecordFlag.Veteran)) {
+            return DungeonEnterLimit.Veteran;
+        }
+
+        return DungeonEnterLimit.Rookie;
     }
 
     public void SetDungeon(DungeonFieldManager field) {
@@ -210,17 +232,21 @@ public class DungeonManager {
         Metadata = field.DungeonMetadata;
         UserRecord = new DungeonUserRecord(field.DungeonId, session.CharacterId);
 
+        foreach (int missionId in Metadata.UserMissions) {
+
+        }
+
         field.DungeonRoomRecord.UserResults.TryAdd(session.CharacterId, UserRecord);
     }
 
     public void CreateDungeonRoom(int dungeonId, bool withParty) {
         int size = 1;
-        if (!session.TableMetadata.DungeonRoomTable.Entries.TryGetValue(dungeonId, out DungeonRoomTable.DungeonRoomMetadata? metadata)) {
+        if (!session.TableMetadata.DungeonRoomTable.Entries.TryGetValue(dungeonId, out DungeonRoomMetadata? metadata)) {
             session.Send(DungeonRoomPacket.Error(DungeonRoomError.s_room_dungeon_notOpenTimeDungeon));
             return;
         }
 
-        if (EnterLimits.TryGetValue(dungeonId, out DungeonEnterLimit limit) && limit != DungeonEnterLimit.None) {
+        if (EnterLimits.TryGetValue(dungeonId, out DungeonEnterLimit limit) && limit != DungeonEnterLimit.Veteran && limit != DungeonEnterLimit.Rookie) {
             session.Send(FieldEntrancePacket.Error(dungeonId, limit));
             return;
         }
@@ -278,6 +304,7 @@ public class DungeonManager {
 
     public void EnterLobby() {
         if (Party == null) {
+            session.Send(MigrationPacket.GameToGameError(MigrationError.s_move_err_NotFoundParty));
             return;
         }
 
@@ -304,7 +331,7 @@ public class DungeonManager {
 
     public void SetDungeon(int dungeonId, int roomId, bool set) {
         if (set) {
-            if (!session.TableMetadata.DungeonRoomTable.Entries.TryGetValue(dungeonId, out DungeonRoomTable.DungeonRoomMetadata? metadata)) {
+            if (!session.TableMetadata.DungeonRoomTable.Entries.TryGetValue(dungeonId, out DungeonRoomMetadata? metadata)) {
                 logger.Error("Dungeon metadata not found for dungeonId {dungeonId}", dungeonId);
                 return;
             }
@@ -317,40 +344,202 @@ public class DungeonManager {
         }
     }
 
-    public void CompleteDungeon() {
+    public void CompleteDungeon(long clearTimestamp) {
         if (Lobby == null || Metadata == null || UserRecord == null) {
             return;
         }
-        DungeonRoomReward metadata = Metadata.Reward;
+        DungeonRoomRewardMetadata metadata = Metadata.Reward;
         UserRecord.IsDungeonSuccess = Lobby.DungeonRoomRecord.State == DungeonState.Clear;
         UserRecord.TotalSeconds = (int) (Lobby.DungeonRoomRecord.EndTick - Lobby.DungeonRoomRecord.StartTick) / 1000;
 
-        int exp = (int) metadata.Exp;
-        if (metadata.ExpRate > 0f) {
-            exp = (int) (metadata.Exp * metadata.ExpRate);
-        }
-        UserRecord.Rewards[DungeonRewardType.Exp] = exp;
-        UserRecord.Rewards[DungeonRewardType.Meso] = (int) metadata.Meso;
-        session.Exp.AddExp(UserRecord.Rewards[DungeonRewardType.Exp]);
-        session.Currency.Meso += UserRecord.Rewards[DungeonRewardType.Meso];
-        session.Send(DungeonRoomPacket.Modify(DungeonRoomModify.GiveReward, Lobby.DungeonId));
-
-        ICollection<Item> items = [];
-        if (metadata.UnlimitedDropBoxIds.Length > 0) {
-            foreach (int boxId in metadata.UnlimitedDropBoxIds) {
-                items = items.Concat(Lobby.ItemDrop.GetIndividualDropItems(boxId)).ToList();
-                items = items.Concat(Lobby.ItemDrop.GetGlobalDropItems(boxId, Metadata.Level)).ToList();
-            }
-        }
-
-        foreach (Item item in items) {
-            UserRecord.RewardItems.Add(item);
-            if (!session.Item.Inventory.Add(item, true)) {
-                session.Item.MailItem(item);
-            }
-        }
+        CalculateRewards(clearTimestamp);
 
         session.Send(DungeonRewardPacket.Dungeon(UserRecord));
+    }
+
+    private void CalculateRewards(long clearTimeStamp) {
+        if (Lobby == null || Metadata == null || UserRecord == null) {
+            return;
+        }
+        DungeonRecord record = GetRecord(Metadata.Id);
+        List<int> rewardIds = [];
+
+        if (Metadata.Reward.UnionRewardId > 0) {
+            if (!session.TableMetadata.DungeonRoomTable.Entries.TryGetValue(Metadata.Reward.UnionRewardId, out DungeonRoomMetadata? unionMetadata)) {
+                return;
+            }
+            DungeonRecord unionRecord = GetRecord(Metadata.Reward.UnionRewardId);
+            // Ensure player can get rewards
+            if (GetDailyClearCount(unionRecord) < unionMetadata.Reward.SubRewardCount && GetWeeklyClearCount(unionRecord) < unionMetadata.Reward.Count) {
+                UpdateUnionRecord(unionRecord, unionMetadata, clearTimeStamp);
+                UserRecord.Flag |= DungeonBonusFlag.Clear;
+            }
+
+            if (session.TableMetadata.DungeonConfigTable.UnitedWeeklyRewards.TryGetValue(GetWeeklyClearCount(unionRecord), out int rewardId)) {
+                UserRecord.Flag |= DungeonBonusFlag.UnitedWeekly;
+                rewardIds.Add(rewardId);
+            }
+
+            UpdateDungeonRecord(record, Metadata, clearTimeStamp);
+
+        } else {
+            if (GetDailyClearCount(record) < Metadata.Reward.SubRewardCount && GetWeeklyClearCount(record) < Metadata.Reward.Count) {
+                UpdateUnionRecord(record, Metadata, clearTimeStamp);
+                UpdateDungeonRecord(record, Metadata, clearTimeStamp);
+                UserRecord.Flag |= DungeonBonusFlag.Clear;
+            }
+        }
+
+        // TODO: If dungeon was dungeon helper, add clear count on dungeon ID 1003
+
+        if (UserRecord.Flag.HasFlag(DungeonBonusFlag.Clear)) {
+            GetClearDungeonRewards();
+        }
+
+        foreach (int rewardId in rewardIds) {
+            RewardRecord rewardRecord = session.GetRewardContent(rewardId);
+            UserRecord.Add(rewardRecord);
+        }
+
+        return;
+
+        void GetClearDungeonRewards() {
+            DungeonRoomRewardMetadata rewardMetadata = Metadata!.Reward;
+            int exp = (int) rewardMetadata.Exp;
+            if (rewardMetadata.ExpRate > 0f) {
+                exp = (int) (rewardMetadata.Exp * rewardMetadata.ExpRate);
+            }
+            UserRecord.Rewards[DungeonRewardType.Exp] = exp;
+            UserRecord.Rewards[DungeonRewardType.Meso] = (int) rewardMetadata.Meso;
+            session.Exp.AddExp(UserRecord.Rewards[DungeonRewardType.Exp]);
+            session.Currency.Meso += UserRecord.Rewards[DungeonRewardType.Meso];
+            session.Send(DungeonRoomPacket.Modify(DungeonRoomModify.GiveReward, Lobby.DungeonId));
+
+            ICollection<Item> items = [];
+            if (rewardMetadata.UnlimitedDropBoxIds.Length > 0) {
+                foreach (int boxId in rewardMetadata.UnlimitedDropBoxIds) {
+                    items = items.Concat(Lobby.ItemDrop.GetIndividualDropItems(boxId)).ToList();
+                    items = items.Concat(Lobby.ItemDrop.GetGlobalDropItems(boxId, Metadata.Level)).ToList();
+                }
+            }
+
+            foreach (Item item in items) {
+                UserRecord.RewardItems.Add(item);
+                if (!session.Item.Inventory.Add(item, true)) {
+                    session.Item.MailItem(item);
+                }
+            }
+        }
+    }
+
+    private void UpdateUnionRecord(DungeonRecord record, DungeonRoomMetadata metadata, long clearTimeStamp) {
+        if (UserRecord == null) {
+            return;
+        }
+        DateTime clearTime = clearTimeStamp.FromEpochSeconds();
+        if (record.ClearTimestamp == 0) {
+            record.ClearTimestamp = clearTimeStamp;
+        }
+        if (clearTimeStamp > record.UnionCooldownTimestamp) {
+            record.UnionCooldownTimestamp = GetCooldownTime(metadata.CooldownType, metadata.CooldownValue, clearTime);
+            record.UnionClears = 0;
+            record.ExtraClears = 0;
+        }
+
+        if (clearTimeStamp > record.UnionSubCooldownTimestamp) {
+            record.UnionSubCooldownTimestamp = new DateTime(clearTime.Year, clearTime.Month, clearTime.Day).AddDays(1).ToEpochSeconds();
+            record.UnionSubClears = 0;
+            record.ExtraSubClears = 0;
+        }
+
+        if (metadata.GroupType == DungeonGroupType.colosseum) {
+            record.UnionClears = (byte) UserRecord.Round;
+        } else {
+            record.UnionClears++;
+            record.UnionSubClears++;
+        }
+
+        if (record.UnionClears <= metadata.Reward.Count) {
+            UserRecord.Flag |= DungeonBonusFlag.UnitedWeekly;
+        }
+
+        if (record.UnionSubClears <= metadata.Reward.SubRewardCount) {
+            UserRecord.Flag |= DungeonBonusFlag.Clear;
+        }
+        session.Send(DungeonRoomPacket.Update(record));
+    }
+
+    private void UpdateDungeonRecord(DungeonRecord record, DungeonRoomMetadata metadata, long clearTimeStamp, bool updateUnion = false) {
+        if (UserRecord == null) {
+            return;
+        }
+        DateTime clearTime = clearTimeStamp.FromEpochSeconds();
+        if (record.ClearTimestamp == 0) {
+            record.ClearTimestamp = clearTimeStamp;
+        }
+
+        if (updateUnion) {
+            UpdateUnionRecord(record, metadata, clearTimeStamp);
+            return;
+        }
+
+        // TODO: Rank score
+        if (metadata.GroupType == DungeonGroupType.colosseum) {
+            record.TotalClears = UserRecord.Round;
+        } else {
+            record.TotalClears++;
+        }
+        record.CooldownTimestamp = GetCooldownTime(metadata.CooldownType, metadata.CooldownValue, clearTime);
+        session.Send(DungeonRoomPacket.Update(record));
+    }
+
+    private int GetDailyClearCount(DungeonRecord record) {
+        if (!session.TableMetadata.DungeonRoomTable.Entries.TryGetValue(record.DungeonId, out DungeonRoomMetadata? metadata)) {
+            return 0;
+        }
+
+        if (metadata.Reward.UnionRewardId > 0) {
+            DungeonRecord unionRecord = GetRecord(metadata.Reward.UnionRewardId);
+            if (DateTime.Now.ToEpochSeconds() > unionRecord.UnionSubCooldownTimestamp) {
+                return 0;
+            }
+            return unionRecord.UnionSubClears;
+        }
+
+        if (DateTime.Now.ToEpochSeconds() > record.UnionSubCooldownTimestamp) {
+            return 0;
+        }
+
+        return record.UnionSubClears;
+    }
+
+    private int GetWeeklyClearCount(DungeonRecord record) {
+        if (!session.TableMetadata.DungeonRoomTable.Entries.TryGetValue(record.DungeonId, out DungeonRoomMetadata? metadata)) {
+            return 0;
+        }
+
+        if (metadata.Reward.UnionRewardId > 0) {
+            DungeonRecord unionRecord = GetRecord(metadata.Reward.UnionRewardId);
+
+            if (DateTime.Now.ToEpochSeconds() > unionRecord.UnionCooldownTimestamp) {
+                return 0;
+            }
+            return unionRecord.UnionClears;
+        }
+
+        if (DateTime.Now.ToEpochSeconds() > record.UnionCooldownTimestamp) {
+            return 0;
+        }
+
+        return record.UnionClears;
+    }
+
+    private long GetCooldownTime(DungeonCooldownType type, int cooldownValue, DateTime clearTime) {
+        return type switch {
+            DungeonCooldownType.nextDay => new DateTime(clearTime.Year, clearTime.Month, clearTime.Day).AddDays(1).ToEpochSeconds(),
+            DungeonCooldownType.dayOfWeeks => DateTime.Now.NextDayOfWeek((DayOfWeek) cooldownValue).ToEpochSeconds(),
+            _ => 0,
+        };
     }
 
     public void Reset() {
@@ -387,6 +576,13 @@ public class DungeonManager {
             session.World.Party(request);
         } catch (RpcException) { }
 
+    }
+
+    private DungeonRecord GetRecord(int dungeonId) {
+        if (!Records.TryGetValue(dungeonId, out DungeonRecord? record)) {
+            Records[dungeonId] = record = new DungeonRecord(dungeonId);
+        }
+        return record;
     }
 
     private void MigrateToDungeon() {

--- a/Maple2.Server.Game/Manager/DungeonManager.cs
+++ b/Maple2.Server.Game/Manager/DungeonManager.cs
@@ -81,14 +81,14 @@ public class DungeonManager {
         if (session.Field.FieldInstance.Type == InstanceType.DungeonLobby) {
             session.Send(DungeonWaitingPacket.Set(Lobby.DungeonId, Lobby.Size));
         } else {
-            session.Send(RoomStageDungeonPacket.Set(Metadata.Id));
+            /*session.Send(RoomStageDungeonPacket.Set(Metadata.Id));
             ByteWriter pWriter = Packet.Of(SendOp.DungeonMission);
             pWriter.WriteByte(0);
             pWriter.WriteInt(1);
             pWriter.WriteInt(23023005);
             pWriter.WriteShort(1);
             pWriter.WriteShort(); // counter
-            session.Send(pWriter);
+            session.Send(pWriter);*/
         }
     }
 

--- a/Maple2.Server.Game/Manager/Field/FieldManager/DungeonFieldManager.cs
+++ b/Maple2.Server.Game/Manager/Field/FieldManager/DungeonFieldManager.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Concurrent;
+using Maple2.Database.Extensions;
 using Maple2.Database.Storage;
 using Maple2.Model.Enum;
 using Maple2.Model.Game.Dungeon;
@@ -9,13 +10,13 @@ using Maple2.Server.Game.Packets;
 namespace Maple2.Server.Game.Manager.Field;
 
 public class DungeonFieldManager : FieldManager {
-    public readonly DungeonRoomTable.DungeonRoomMetadata DungeonMetadata;
+    public readonly DungeonRoomMetadata DungeonMetadata;
     public DungeonFieldManager? Lobby { get; init; }
     public readonly ConcurrentDictionary<int, DungeonFieldManager> RoomFields = [];
     public required DungeonRoomRecord DungeonRoomRecord { get; init; }
     public int PartyId { get; init; }
 
-    public DungeonFieldManager(DungeonRoomTable.DungeonRoomMetadata dungeonMetadata, MapMetadata mapMetadata, UgcMapMetadata ugcMetadata, MapEntityMetadata entities, NpcMetadataStorage npcMetadata, long ownerId = 0, int size = 1, int partyId = 0)
+    public DungeonFieldManager(DungeonRoomMetadata dungeonMetadata, MapMetadata mapMetadata, UgcMapMetadata ugcMetadata, MapEntityMetadata entities, NpcMetadataStorage npcMetadata, long ownerId = 0, int size = 1, int partyId = 0)
         : base(mapMetadata, ugcMetadata, entities, npcMetadata, ownerId) {
         DungeonMetadata = dungeonMetadata;
         if (dungeonMetadata.LobbyFieldId == mapMetadata.Id) {
@@ -56,12 +57,13 @@ public class DungeonFieldManager : FieldManager {
         Broadcast(DungeonRoomPacket.DungeonResult(DungeonRoomRecord.State, compiledResults));
 
         if (DungeonRoomRecord.State == DungeonState.Clear) {
+            long clearTimestamp = DateTime.Now.ToEpochSeconds();
             foreach (long characterId in compiledResults.Keys) {
                 if (!TryGetPlayerById(characterId, out FieldPlayer? player)) {
                     continue;
                 }
 
-                player.Session.Dungeon.CompleteDungeon();
+                player.Session.Dungeon.CompleteDungeon(clearTimestamp);
 
             }
         }

--- a/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.Factory.cs
+++ b/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.Factory.cs
@@ -143,7 +143,7 @@ public partial class FieldManager {
             return field;
         }
 
-        public DungeonFieldManager? CreateDungeon(DungeonRoomTable.DungeonRoomMetadata dungeonMetadata, long ownerId, int size = 1, int partyId = 0) {
+        public DungeonFieldManager? CreateDungeon(DungeonRoomMetadata dungeonMetadata, long ownerId, int size = 1, int partyId = 0) {
             var sw = new Stopwatch();
             sw.Start();
 

--- a/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.State.cs
+++ b/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.State.cs
@@ -736,13 +736,7 @@ public partial class FieldManager {
 
     #region Events
     public void OnAddPlayer(FieldPlayer added) {
-        if (Players.IsEmpty) {
-            Players[added.ObjectId] = added;
-            // Add delay to ensure floor is loaded, triggers have ran.
-            Task.Delay(200).Wait();
-        } else {
-            Players[added.ObjectId] = added;
-        }
+        Players[added.ObjectId] = added;
         // LOAD:
         foreach (FieldLiftable liftable in fieldLiftables.Values.Where(liftable => liftable.FinishTick > 0)) {
             added.Session.Send(LiftablePacket.Add(liftable));

--- a/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.State.cs
+++ b/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.State.cs
@@ -736,7 +736,13 @@ public partial class FieldManager {
 
     #region Events
     public void OnAddPlayer(FieldPlayer added) {
-        Players[added.ObjectId] = added;
+        if (Players.IsEmpty) {
+            Players[added.ObjectId] = added;
+            // Add delay to ensure floor is loaded, triggers have ran.
+            Task.Delay(200).Wait();
+        } else {
+            Players[added.ObjectId] = added;
+        }
         // LOAD:
         foreach (FieldLiftable liftable in fieldLiftables.Values.Where(liftable => liftable.FinishTick > 0)) {
             added.Session.Send(LiftablePacket.Add(liftable));

--- a/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.cs
+++ b/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.cs
@@ -254,7 +254,7 @@ public partial class FieldManager : IField {
             }
 
             // Environment.TickCount has ~16ms precision so sleep until next update
-            Thread.Sleep(5);
+            Thread.Sleep(15);
         }
     }
 

--- a/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.cs
+++ b/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.cs
@@ -254,7 +254,7 @@ public partial class FieldManager : IField {
             }
 
             // Environment.TickCount has ~16ms precision so sleep until next update
-            Thread.Sleep(15);
+            Thread.Sleep(5);
         }
     }
 
@@ -600,7 +600,7 @@ public partial class FieldManager : IField {
 
         foreach (FieldPlayer fieldPlayer in Players.Values) {
             NpcScriptManager? npcScript = fieldPlayer.Session.NpcScript;
-            if (npcScript is not null && npcScript.Npc.Value.Id == npc.Value.Id && npc.Value.Metadata.LookAtTarget.UseTalkMotion) {
+            if (npcScript is not null && npcScript.Npc is not null && npcScript.Npc.Value.Id == npc.Value.Id && npc.Value.Metadata.LookAtTarget.UseTalkMotion) {
                 fieldPlayer.Session.Send(NpcControlPacket.Talk(npc));
                 continue;
             }

--- a/Maple2.Server.Game/Manager/ItemMergeManager.cs
+++ b/Maple2.Server.Game/Manager/ItemMergeManager.cs
@@ -92,7 +92,6 @@ public sealed class ItemMergeManager {
 
         CinematicEventScript[] eventScripts = state.Contents.First().Events;
         session.NpcScript = new NpcScriptManager(session, eventScripts);
-        session.NpcScript.Event();
     }
 
     public void Empower(long itemUid, long catalystUid) {
@@ -157,7 +156,7 @@ public sealed class ItemMergeManager {
         }
 
         session.Send(ItemMergePacket.Empower(upgradeItem));
-        session.NpcScript?.Event();
+        session.NpcScript?.EmpowerEvent();
         session.ConditionUpdate(ConditionType.item_merge_success);
 
         return;

--- a/Maple2.Server.Game/Manager/Items/ItemDropManager.cs
+++ b/Maple2.Server.Game/Manager/Items/ItemDropManager.cs
@@ -239,7 +239,11 @@ public class ItemDropManager {
                 createdItem.Transfer?.Bind(character);
             }
 
-            // TODO: SockDataId, EnchantLevel, DisableBreak, Announce
+            if (selectedItem.EnchantLevel > 0) {
+                createdItem.Enchant = ItemEnchantManager.GetEnchant(field.ServerTableMetadata.EnchantOptionTable, createdItem, selectedItem.EnchantLevel);
+            }
+
+            // TODO: SockDataId, DisableBreak, Announce
 
             yield return createdItem;
         }

--- a/Maple2.Server.Game/PacketHandlers/ItemEnchantHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/ItemEnchantHandler.cs
@@ -1,7 +1,9 @@
 ﻿using Maple2.Model.Enum;
+using Maple2.Model.Metadata;
 using Maple2.PacketLib.Tools;
 using Maple2.Server.Core.Constants;
 using Maple2.Server.Core.PacketHandlers;
+using Maple2.Server.Game.Manager;
 using Maple2.Server.Game.Session;
 
 namespace Maple2.Server.Game.PacketHandlers;

--- a/Maple2.Server.Game/PacketHandlers/LoadUgcMapHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/LoadUgcMapHandler.cs
@@ -70,9 +70,6 @@ public class LoadUgcMapHandler : PacketHandler<GameSession> {
         session.Send(LoadUgcMapPacket.LoadHome(plotCubes.Count, home));
 
         LoadPlots(session, plotCubes);
-
-        // this is a workaround for the client to load the map before field add player - without this, player will fall and get tp'd back to 0,0
-        Task.Delay(200).Wait();
     }
 
     private static void LoadPlots(GameSession session, List<PlotCube> plotCubes) {

--- a/Maple2.Server.Game/Packets/DungeonMissionPacket.cs
+++ b/Maple2.Server.Game/Packets/DungeonMissionPacket.cs
@@ -1,0 +1,45 @@
+﻿using Maple2.Model.Game.Dungeon;
+using Maple2.PacketLib.Tools;
+using Maple2.Server.Core.Constants;
+using Maple2.Server.Core.Packets;
+using Maple2.Tools.Extensions;
+
+namespace Maple2.Server.Game.Packets;
+
+public static class DungeonMissionPacket {
+    private enum Command : byte {
+        Load = 0,
+        Update = 1,
+        SetAbandon = 4,
+    }
+
+    public static ByteWriter Load(IDictionary<int, DungeonMission> missions) {
+        var pWriter = Packet.Of(SendOp.DungeonMission);
+        pWriter.Write<Command>(Command.Load);
+        pWriter.WriteInt(missions.Count);
+        foreach ((int id, DungeonMission mission) in missions) {
+            pWriter.WriteClass<DungeonMission>(mission);
+        }
+
+        return pWriter;
+    }
+
+    public static ByteWriter Update(params DungeonMission[] missions) {
+        var pWriter = Packet.Of(SendOp.DungeonMission);
+        pWriter.Write<Command>(Command.Update);
+        pWriter.WriteInt(missions.Length);
+        foreach (DungeonMission mission in missions) {
+            pWriter.WriteClass<DungeonMission>(mission);
+        }
+
+        return pWriter;
+    }
+
+    public static ByteWriter SetAbandon(bool enable) {
+        var pWriter = Packet.Of(SendOp.DungeonMission);
+        pWriter.Write<Command>(Command.SetAbandon);
+        pWriter.WriteBool(enable);
+
+        return pWriter;
+    }
+}

--- a/Maple2.Server.Game/Packets/DungeonRoomPacket.cs
+++ b/Maple2.Server.Game/Packets/DungeonRoomPacket.cs
@@ -54,7 +54,7 @@ public static class DungeonRoomPacket {
         pWriter.WriteInt(statistics.Count);
         foreach (DungeonUserResult userResult in statistics.Values) {
             pWriter.WriteLong(userResult.CharacterId);
-            pWriter.Write<DungeonGrade>(userResult.Grade);
+            pWriter.Write<DungeonMissionRank>(userResult.MissionRank);
             pWriter.Write<DungeonAccumulationRecordType>(userResult.RecordType);
             pWriter.WriteInt(userResult.Value);
         }

--- a/Maple2.Server.Game/Packets/EnchantScrollPacket.cs
+++ b/Maple2.Server.Game/Packets/EnchantScrollPacket.cs
@@ -21,7 +21,7 @@ public static class EnchantScrollPacket {
         var pWriter = Packet.Of(SendOp.EnchantScroll);
         pWriter.Write<Command>(Command.UseScroll);
         pWriter.WriteLong(item.Uid);
-        pWriter.WriteShort(metadata.Type);
+        pWriter.Write<EnchantScrollType>(metadata.Type);
         pWriter.WriteBool(false);
         pWriter.WriteInt(metadata.Enchants.Max());
         pWriter.WriteInt(10000); // div 100 = Rate
@@ -35,7 +35,8 @@ public static class EnchantScrollPacket {
         foreach (int rarity in metadata.Rarities) {
             pWriter.WriteInt(rarity);
         }
-        if (metadata.Type == 3) {
+
+        if (metadata.Type == EnchantScrollType.Random) {
             pWriter.WriteInt(metadata.Enchants.Min());
             pWriter.WriteInt(metadata.Enchants.Max());
         }
@@ -43,14 +44,14 @@ public static class EnchantScrollPacket {
         return pWriter;
     }
 
-    public static ByteWriter Preview(Item item, short scrollType, IDictionary<BasicAttribute, BasicOption> minOptions, IDictionary<BasicAttribute, BasicOption> maxOptions) {
+    public static ByteWriter Preview(Item item, EnchantScrollType scrollType, IDictionary<BasicAttribute, BasicOption> minOptions, IDictionary<BasicAttribute, BasicOption> maxOptions) {
         var pWriter = Packet.Of(SendOp.EnchantScroll);
         pWriter.Write<Command>(Command.Preview);
         pWriter.WriteLong(item.Uid);
-        pWriter.WriteShort(scrollType);
+        pWriter.Write<EnchantScrollType>(scrollType);
 
         switch (scrollType) {
-            case 1 or 2:
+            case EnchantScrollType.Enchant or EnchantScrollType.Restore:
                 pWriter.WriteInt(minOptions.Count);
                 foreach ((BasicAttribute attribute, BasicOption delta) in minOptions) {
                     pWriter.WriteShort((short) attribute);
@@ -58,21 +59,21 @@ public static class EnchantScrollPacket {
                     pWriter.WriteInt(delta.Value);
                 }
                 break;
-            case 3:
-                pWriter.WriteInt(minOptions.Count);
-                foreach ((BasicAttribute attribute, BasicOption delta) in minOptions) {
-                    pWriter.WriteShort((short) attribute);
-                    pWriter.WriteFloat(delta.Rate);
-                    pWriter.WriteInt(delta.Value);
-                }
+            case EnchantScrollType.Random:
                 pWriter.WriteInt(maxOptions.Count);
                 foreach ((BasicAttribute attribute, BasicOption delta) in maxOptions) {
                     pWriter.WriteShort((short) attribute);
                     pWriter.WriteFloat(delta.Rate);
                     pWriter.WriteInt(delta.Value);
                 }
+                pWriter.WriteInt(minOptions.Count);
+                foreach ((BasicAttribute attribute, BasicOption delta) in minOptions) {
+                    pWriter.WriteShort((short) attribute);
+                    pWriter.WriteFloat(delta.Rate);
+                    pWriter.WriteInt(delta.Value);
+                }
                 break;
-            case 5:
+            case EnchantScrollType.Stabilize:
                 break;
         }
 

--- a/Maple2.Server.Game/Packets/ItemEnchantPacket.cs
+++ b/Maple2.Server.Game/Packets/ItemEnchantPacket.cs
@@ -33,7 +33,7 @@ public static class ItemEnchantPacket {
             pWriter.Write<IngredientInfo>(catalyst);
         }
 
-        pWriter.WriteShort();
+        pWriter.Write<EnchantFailType>(EnchantFailType.None);
 
         pWriter.WriteInt(statDeltas.Count);
         foreach ((BasicAttribute attribute, BasicOption delta) in statDeltas) {

--- a/Maple2.Server.Game/Packets/RoomStageDungeonPacket.cs
+++ b/Maple2.Server.Game/Packets/RoomStageDungeonPacket.cs
@@ -7,6 +7,7 @@ namespace Maple2.Server.Game.Packets;
 public static class RoomStageDungeonPacket {
     private enum Command : byte {
         Set = 0,
+        Update = 1,
     }
 
     public static ByteWriter Set(int dungeonId) {
@@ -15,6 +16,14 @@ public static class RoomStageDungeonPacket {
         pWriter.WriteInt(dungeonId);
         pWriter.WriteInt();
         pWriter.WriteShort();
+
+        return pWriter;
+    }
+
+    public static ByteWriter Update(int value) {
+        var pWriter = Packet.Of(SendOp.RoomStageDungeon);
+        pWriter.Write<Command>(Command.Update);
+        pWriter.WriteInt(value);
 
         return pWriter;
     }

--- a/Maple2.Server.Game/Packets/TriggerPacket.cs
+++ b/Maple2.Server.Game/Packets/TriggerPacket.cs
@@ -131,21 +131,15 @@ public static class TriggerPacket {
         return pWriter;
     }
 
-    public static ByteWriter DuelHpBar(int objectId, int durationTick, int hpStep) {
+    public static ByteWriter DuelHpBar(bool set, int objectId = 0, int durationTick = 0, int hpStep = 0) {
         var pWriter = Packet.Of(SendOp.Trigger);
         pWriter.Write<Command>(Command.DuelHpBar);
-        pWriter.WriteBool(true);
-        pWriter.WriteInt(objectId);
-        pWriter.WriteInt(durationTick);
-        pWriter.WriteInt(hpStep);
-
-        return pWriter;
-    }
-
-    public static ByteWriter HideDuelHpBar() {
-        var pWriter = Packet.Of(SendOp.Trigger);
-        pWriter.Write<Command>(Command.DuelHpBar);
-        pWriter.WriteBool(false);
+        pWriter.WriteBool(set);
+        if (set) {
+            pWriter.WriteInt(objectId);
+            pWriter.WriteInt(durationTick);
+            pWriter.WriteInt(hpStep);
+        }
 
         return pWriter;
     }

--- a/Maple2.Server.Game/Service/ChannelService.Field.cs
+++ b/Maple2.Server.Game/Service/ChannelService.Field.cs
@@ -18,7 +18,7 @@ public partial class ChannelService {
     }
 
     private FieldResponse CreateDungeon(FieldRequest.Types.CreateDungeon create, long requestorId) {
-        if (!tableMetadata.DungeonRoomTable.Entries.TryGetValue(create.DungeonId, out DungeonRoomTable.DungeonRoomMetadata? dungeonRoom)) {
+        if (!tableMetadata.DungeonRoomTable.Entries.TryGetValue(create.DungeonId, out DungeonRoomMetadata? dungeonRoom)) {
             return new FieldResponse {
                 Error = (int) MigrationError.s_move_err_dungeon_not_exist,
             };

--- a/Maple2.Server.Game/Session/GameSession.cs
+++ b/Maple2.Server.Game/Session/GameSession.cs
@@ -571,7 +571,7 @@ public sealed partial class GameSession : Core.Network.Session {
                 }
             }
             foreach (Item item in items) {
-                if (!Item.Inventory.Add(item)) {
+                if (!Item.Inventory.Add(item, true)) {
                     Item.MailItem(item);
                 }
             }

--- a/Maple2.Server.Game/Trigger/TriggerContext.Dungeon.cs
+++ b/Maple2.Server.Game/Trigger/TriggerContext.Dungeon.cs
@@ -50,7 +50,7 @@ public partial class TriggerContext {
     }
 
     public void DungeonMissionComplete(string feature, int missionId) {
-        ErrorLog("[DungeonMissionComplete] missionId:{MissionId}, feature:{Feature}", missionId, feature);
+        DebugLog("[DungeonMissionComplete] missionId:{MissionId}, feature:{Feature}", missionId, feature);
 
         foreach (FieldPlayer player in Field.Players.Values) {
             if (player.Session.Dungeon.UserRecord is null) {

--- a/Maple2.Server.Game/Trigger/TriggerContext.Npc.cs
+++ b/Maple2.Server.Game/Trigger/TriggerContext.Npc.cs
@@ -141,7 +141,13 @@ public partial class TriggerContext {
     }
 
     public void SetNpcDuelHpBar(bool isOpen, int spawnId, int durationTick, int npcHpStep) {
-        ErrorLog("[SetNpcDuelHpBar] isOpen:{IsOpen}, spawnId:{SpawnId}, durationTick:{Duration}, npcHpStep:{HpStep}", isOpen, spawnId, durationTick, npcHpStep);
+        DebugLog("[SetNpcDuelHpBar] isOpen:{IsOpen}, spawnId:{SpawnId}, durationTick:{Duration}, npcHpStep:{HpStep}", isOpen, spawnId, durationTick, npcHpStep);
+        IActor? actor = Field.GetActorsBySpawnId(spawnId).FirstOrDefault();
+        if (actor is null) {
+            return;
+        }
+
+        Broadcast(TriggerPacket.DuelHpBar(isOpen, actor.ObjectId, durationTick, npcHpStep));
     }
 
     public void SetNpcEmotionLoop(int spawnId, string sequenceName, float duration) {

--- a/Maple2.Server.World/Migrations/20250331233640_DungeonInfo2.Designer.cs
+++ b/Maple2.Server.World/Migrations/20250331233640_DungeonInfo2.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Maple2.Database.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Maple2.Server.World.Migrations
 {
     [DbContext(typeof(Ms2Context))]
-    partial class Ms2ContextModelSnapshot : ModelSnapshot
+    [Migration("20250331233640_DungeonInfo2")]
+    partial class DungeonInfo2
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Maple2.Server.World/Migrations/20250331233640_DungeonInfo2.cs
+++ b/Maple2.Server.World/Migrations/20250331233640_DungeonInfo2.cs
@@ -3,14 +3,11 @@ using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
-namespace Maple2.Server.World.Migrations
-{
+namespace Maple2.Server.World.Migrations {
     /// <inheritdoc />
-    public partial class DungeonInfo2 : Migration
-    {
+    public partial class DungeonInfo2 : Migration {
         /// <inheritdoc />
-        protected override void Up(MigrationBuilder migrationBuilder)
-        {
+        protected override void Up(MigrationBuilder migrationBuilder) {
             migrationBuilder.RenameColumn(
                 name: "WeeklyResetTime",
                 table: "dungeon-record",
@@ -53,12 +50,11 @@ namespace Maple2.Server.World.Migrations
                 table: "dungeon-record",
                 type: "tinyint unsigned",
                 nullable: false,
-                defaultValue: (byte)0);
+                defaultValue: (byte) 0);
         }
 
         /// <inheritdoc />
-        protected override void Down(MigrationBuilder migrationBuilder)
-        {
+        protected override void Down(MigrationBuilder migrationBuilder) {
             migrationBuilder.DropColumn(
                 name: "CooldownTime",
                 table: "dungeon-record");

--- a/Maple2.Server.World/Migrations/20250331233640_DungeonInfo2.cs
+++ b/Maple2.Server.World/Migrations/20250331233640_DungeonInfo2.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Maple2.Server.World.Migrations
+{
+    /// <inheritdoc />
+    public partial class DungeonInfo2 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "WeeklyResetTime",
+                table: "dungeon-record",
+                newName: "UnionCooldownTime");
+
+            migrationBuilder.RenameColumn(
+                name: "WeeklyRecord",
+                table: "dungeon-record",
+                newName: "CurrentRecord");
+
+            migrationBuilder.RenameColumn(
+                name: "WeeklyClears",
+                table: "dungeon-record",
+                newName: "Flag");
+
+            migrationBuilder.RenameColumn(
+                name: "ExtraWeeklyClears",
+                table: "dungeon-record",
+                newName: "ExtraCurrentSubClears");
+
+            migrationBuilder.RenameColumn(
+                name: "ExtraDailyClears",
+                table: "dungeon-record",
+                newName: "ExtraCurrentClears");
+
+            migrationBuilder.RenameColumn(
+                name: "DailyClears",
+                table: "dungeon-record",
+                newName: "CurrentSubClears");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "CooldownTime",
+                table: "dungeon-record",
+                type: "datetime(6)",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AddColumn<byte>(
+                name: "CurrentClears",
+                table: "dungeon-record",
+                type: "tinyint unsigned",
+                nullable: false,
+                defaultValue: (byte)0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CooldownTime",
+                table: "dungeon-record");
+
+            migrationBuilder.DropColumn(
+                name: "CurrentClears",
+                table: "dungeon-record");
+
+            migrationBuilder.RenameColumn(
+                name: "UnionCooldownTime",
+                table: "dungeon-record",
+                newName: "WeeklyResetTime");
+
+            migrationBuilder.RenameColumn(
+                name: "Flag",
+                table: "dungeon-record",
+                newName: "WeeklyClears");
+
+            migrationBuilder.RenameColumn(
+                name: "ExtraCurrentSubClears",
+                table: "dungeon-record",
+                newName: "ExtraWeeklyClears");
+
+            migrationBuilder.RenameColumn(
+                name: "ExtraCurrentClears",
+                table: "dungeon-record",
+                newName: "ExtraDailyClears");
+
+            migrationBuilder.RenameColumn(
+                name: "CurrentSubClears",
+                table: "dungeon-record",
+                newName: "DailyClears");
+
+            migrationBuilder.RenameColumn(
+                name: "CurrentRecord",
+                table: "dungeon-record",
+                newName: "WeeklyRecord");
+        }
+    }
+}


### PR DESCRIPTION
- Ophelia Enchanting Mat Cost. Roughly 98% align to KMS2 material cost
- Some various dungeon triggers
- Updated on Dungeon Record for user.
- Parse more dungeon tables

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Dynamic dungeon missions now deliver refined rewards and mission tracking.
  - New enchantment scroll types and enriched options offer a more engaging item enhancement experience.
  - Enhanced dungeon record tracking with new properties for clear counts and cooldown management.
  - Improved handling of enchantment results and error reporting during item enchanting.

- **Bug Fixes**
  - Improved stability in NPC interactions and dungeon event handling reduces unexpected behavior.

- **Refactor/Enhancements**
  - Streamlined record and metadata management improves overall performance and responsiveness in dungeon and item systems.
  - Simplified type references in dungeon management for clearer code and improved maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->