### PR TITLE
Fix: Get Field if no room id is specified

### DIFF
--- a/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.Factory.cs
+++ b/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.Factory.cs
@@ -372,6 +372,13 @@ public partial class FieldManager {
                 return Create(mapId, ownerId: ownerId, roomId: roomId);
             }
 
+            if (roomId == 0 && mapFields.Count > 0) {
+                FieldManager? firstField = mapFields.Values.FirstOrDefault();
+                if (firstField != null) {
+                    return firstField;
+                }
+            }
+
             return mapFields.TryGetValue(roomId, out FieldManager? field) ? field :
                 Create(mapId, ownerId: ownerId, roomId: roomId);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved game session assignment: When players join without specifying a session, the system now reliably connects them to an existing game area, avoiding the unnecessary creation of new sessions. This enhancement ensures quicker matchmaking, reduces delays, streamlines the connection process, and significantly boosts overall system performance for a smoother gaming experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->