### PR TITLE
Feat: Death & Revive

### DIFF
--- a/Maple2.Database/Model/CharacterConfig.cs
+++ b/Maple2.Database/Model/CharacterConfig.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using Maple2.Database.Extensions;
+﻿using Maple2.Database.Extensions;
 using Maple2.Model.Enum;
 using Maple2.Model.Game;
 using Microsoft.EntityFrameworkCore;
@@ -23,8 +19,7 @@ internal class CharacterConfig {
     public IList<int>? FavoriteStickers { get; set; }
     public IList<long>? FavoriteDesigners { get; set; }
     public IDictionary<LapenshardSlot, int>? Lapenshards { get; set; }
-    public long DeathTick { get; set; }
-    public int DeathCount { get; set; }
+    public int InstantRevivalCount { get; set; }
     public IDictionary<int, int>? GatheringCounts { get; set; }
     public IDictionary<int, int>? GuideRecords { get; set; }
     public int ExplorationProgress { get; set; }

--- a/Maple2.Database/Storage/Game/GameStorage.ServerInfo.cs
+++ b/Maple2.Database/Storage/Game/GameStorage.ServerInfo.cs
@@ -32,6 +32,7 @@ public partial class GameStorage {
                 Context.Database.ExecuteSqlRaw("UPDATE `account` SET `PrestigeLevelsGained` = DEFAULT");
                 Context.Database.ExecuteSqlRaw("UPDATE `account` SET `PremiumRewardsClaimed` = DEFAULT");
                 Context.Database.ExecuteSqlRaw("UPDATE `character-config` SET `GatheringCounts` = DEFAULT");
+                Context.Database.ExecuteSqlRaw("UPDATE `character-config` SET `InstantRevivalCount` = 0");
                 Context.Database.ExecuteSqlRaw("UPDATE `nurturing` SET `PlayedBy` = '[]'");
                 Context.Database.ExecuteSqlRaw("UPDATE `home` SET `DecorationRewardTimestamp` = 0");
                 // TODO: Death counter

--- a/Maple2.Database/Storage/Game/GameStorage.User.cs
+++ b/Maple2.Database/Storage/Game/GameStorage.User.cs
@@ -310,11 +310,11 @@ public partial class GameStorage {
         }
 
         public (IList<KeyBind>? KeyBinds, IList<QuickSlot[]>? HotBars, List<SkillMacro>?, List<Wardrobe>?, List<int>? FavoriteStickers, List<long>? FavoriteDesigners,
-            IDictionary<LapenshardSlot, int>? Lapenshards, long DeathTick, int DeathCount, int ExplorationProgress, IDictionary<AttributePointSource, int>?,
+            IDictionary<LapenshardSlot, int>? Lapenshards, int InstantRevivalCount, int ExplorationProgress, IDictionary<AttributePointSource, int>?,
             IDictionary<BasicAttribute, int>?, SkillPoint? SkillPoint, IDictionary<int, int>? GatheringCounts, IDictionary<int, int>? GuideRecords, SkillBook?) LoadCharacterConfig(long characterId) {
             CharacterConfig? config = Context.CharacterConfig.Find(characterId);
             if (config == null) {
-                return (null, null, null, null, null, null, null, 0, 0, 0, null, null, null, null, null, null);
+                return (null, null, null, null, null, null, null, 0, 0, null, null, null, null, null, null);
             }
 
             SkillBook? skillBook = config.SkillBook == null ? null : new SkillBook {
@@ -344,8 +344,7 @@ public partial class GameStorage {
                 config.FavoriteStickers?.Select(stickers => stickers).ToList(),
                 config.FavoriteDesigners?.Select(designer => designer).ToList(),
                 config.Lapenshards,
-                config.DeathTick,
-                config.DeathCount,
+                config.InstantRevivalCount,
                 config.ExplorationProgress,
                 config.StatPoints,
                 config.StatAllocation,
@@ -365,9 +364,7 @@ public partial class GameStorage {
             IList<int> favoriteStickers,
             IList<long> favoriteDesigners,
             IDictionary<LapenshardSlot, int> lapenshards,
-            IList<SkillCooldown> skillCooldowns,
-            long deathTick,
-            int deathCount,
+            int instantRevivalCount,
             int explorationProgress,
             StatAttributes.PointAllocation allocation,
             StatAttributes.PointSources statSources,
@@ -389,8 +386,7 @@ public partial class GameStorage {
             config.FavoriteStickers = favoriteStickers;
             config.FavoriteDesigners = favoriteDesigners;
             config.Lapenshards = lapenshards;
-            config.DeathTick = deathTick;
-            config.DeathCount = deathCount;
+            config.InstantRevivalCount = instantRevivalCount;
             config.ExplorationProgress = explorationProgress;
             config.StatAllocation = allocation.Attributes.ToDictionary(
                 attribute => attribute,

--- a/Maple2.File.Ingest/Maple2.File.Ingest.csproj
+++ b/Maple2.File.Ingest/Maple2.File.Ingest.csproj
@@ -19,7 +19,7 @@
     <ItemGroup>
         <PackageReference Include="Crc32.NET" Version="1.2.0" />
         <PackageReference Include="CsvHelper" Version="32.0.2" />
-        <PackageReference Include="Maple2.File.Parser.Tadeucci" Version="2.2.4" />
+        <PackageReference Include="Maple2.File.Parser.Tadeucci" Version="2.2.6" />
         <PackageReference Include="DotRecast.Core" Version="2024.2.3" />
         <PackageReference Include="DotRecast.Detour" Version="2024.2.3" />
         <PackageReference Include="DotRecast.Recast" Version="2024.2.3" />

--- a/Maple2.File.Ingest/Mapper/MapMapper.cs
+++ b/Maple2.File.Ingest/Mapper/MapMapper.cs
@@ -52,7 +52,7 @@ public class MapMapper : TypeMapper<MapMetadata> {
                     TutorialType: data.property.tutorialType,
                     RevivalReturnId: data.property.revivalreturnid,
                     EnterReturnId: data.property.enterreturnid,
-                    AutoRevivalType: data.property.autoRevivalType,
+                    AutoRevivalType: (AutoReviveType) data.property.autoRevivalType,
                     AutoRevivalTime: data.property.autoRevivalTime,
                     InfiniteMeretRevival: data.property.infinityMeratRevival,
                     NoRevivalHere: data.property.doNotRevivalHere,

--- a/Maple2.File.Ingest/Mapper/ServerTableMapper.cs
+++ b/Maple2.File.Ingest/Mapper/ServerTableMapper.cs
@@ -148,6 +148,7 @@ public class ServerTableMapper : TypeMapper<ServerTableMetadata> {
                     Meso: ParseToIntKeyValuePair(scriptCondition.meso),
                     Level: ParseToIntKeyValuePair(scriptCondition.level),
                     AchieveCompleted: ParseToIntKeyValuePair(scriptCondition.achieve_complete),
+                    DeathPenalty: scriptCondition.panelty == 1,
                     InGuild: scriptCondition.guild
                 ));
             }
@@ -210,7 +211,8 @@ public class ServerTableMapper : TypeMapper<ServerTableMetadata> {
                     Meso: ParseToIntKeyValuePair(scriptCondition.meso),
                     Level: ParseToIntKeyValuePair(scriptCondition.level),
                     AchieveCompleted: ParseToIntKeyValuePair(scriptCondition.achieve_complete),
-                    InGuild: scriptCondition.guild
+                    InGuild: scriptCondition.guild,
+                    DeathPenalty: scriptCondition.panelty == 1
                 ));
             }
             results.Add(questId, scriptConditions);
@@ -391,7 +393,8 @@ public class ServerTableMapper : TypeMapper<ServerTableMetadata> {
                 ChangeToJobCode: (JobCode) jobCondition.jobCode,
                 MapId: jobCondition.map,
                 MoveMapId: jobCondition.moveFieldID,
-                MovePortalId: jobCondition.movePortalID
+                MovePortalId: jobCondition.movePortalID,
+                DeathPenalty: jobCondition.panelty
             ));
         }
 

--- a/Maple2.File.Ingest/MapperExtensions.cs
+++ b/Maple2.File.Ingest/MapperExtensions.cs
@@ -327,6 +327,7 @@ public static class MapperExtensions {
             CooldownTime: beginCondition.cooldownTime,
             OnlyShadowWorld: beginCondition.onlyShadowWorld || beginCondition.isShadowWorld,
             OnlyFlyableMap: beginCondition.onlyFlyableMap,
+            AllowDead: beginCondition.allowDeadState,
             Weapon: beginCondition.weapon.Select(weapon => new BeginConditionWeapon(
                 new ItemType(1, (byte) weapon.lh),
                 new ItemType(1, (byte) weapon.rh))).ToArray(),

--- a/Maple2.File.Ingest/Program.cs
+++ b/Maple2.File.Ingest/Program.cs
@@ -187,7 +187,7 @@ var modelReaders = new List<PrefixedM2dReader> {
 };
 
 UpdateDatabase(metadataContext, new ServerTableMapper(serverReader));
-UpdateDatabase(metadataContext, new AiMapper(serverReader));
+/*UpdateDatabase(metadataContext, new AiMapper(serverReader));
 
 UpdateDatabase(metadataContext, new AdditionalEffectMapper(xmlReader));
 UpdateDatabase(metadataContext, new AnimationMapper(xmlReader));
@@ -218,9 +218,9 @@ UpdateDatabase(metadataContext, new MapEntityMapper(metadataContext, parser));
 
 MapDataMapper mapDataMapper = new MapDataMapper(metadataContext, parser);
 
-UpdateDatabase(metadataContext, mapDataMapper);
+UpdateDatabase(metadataContext, mapDataMapper);*/
 
-mapDataMapper.ReportStats();
+//mapDataMapper.ReportStats();
 
 if (runNavmesh) {
     _ = new NavMeshMapper(metadataContext, exportedReader);

--- a/Maple2.File.Ingest/Program.cs
+++ b/Maple2.File.Ingest/Program.cs
@@ -187,7 +187,7 @@ var modelReaders = new List<PrefixedM2dReader> {
 };
 
 UpdateDatabase(metadataContext, new ServerTableMapper(serverReader));
-/*UpdateDatabase(metadataContext, new AiMapper(serverReader));
+UpdateDatabase(metadataContext, new AiMapper(serverReader));
 
 UpdateDatabase(metadataContext, new AdditionalEffectMapper(xmlReader));
 UpdateDatabase(metadataContext, new AnimationMapper(xmlReader));
@@ -218,9 +218,9 @@ UpdateDatabase(metadataContext, new MapEntityMapper(metadataContext, parser));
 
 MapDataMapper mapDataMapper = new MapDataMapper(metadataContext, parser);
 
-UpdateDatabase(metadataContext, mapDataMapper);*/
+UpdateDatabase(metadataContext, mapDataMapper);
 
-//mapDataMapper.ReportStats();
+mapDataMapper.ReportStats();
 
 if (runNavmesh) {
     _ = new NavMeshMapper(metadataContext, exportedReader);

--- a/Maple2.Model/Enum/Death.cs
+++ b/Maple2.Model/Enum/Death.cs
@@ -1,0 +1,7 @@
+﻿namespace Maple2.Model.Enum;
+
+public enum DeathState : short {
+    Alive = 0,
+    FirstDeath = 1,
+    Metal = 2,
+}

--- a/Maple2.Model/Enum/Map.cs
+++ b/Maple2.Model/Enum/Map.cs
@@ -47,3 +47,9 @@ public enum Continent {
     Kritias = 105,
     ShadowWorld = 202,
 }
+
+public enum AutoReviveType {
+    None = 0,
+    Trigger = 1,
+    Countdown = 2, // Only map 65000003 - Treasure Island. Uses autoRevivalTime
+}

--- a/Maple2.Model/Game/User/Character.cs
+++ b/Maple2.Model/Game/User/Character.cs
@@ -37,7 +37,6 @@ public class Character {
     public long StorageCooldown;
     public long DoctorCooldown;
 
-    public int ReviveMapId;
     public int ReturnMapId;
     public Vector3 ReturnPosition;
     public string Picture = string.Empty;

--- a/Maple2.Model/Game/User/Character.cs
+++ b/Maple2.Model/Game/User/Character.cs
@@ -49,5 +49,8 @@ public class Character {
     public AchievementInfo AchievementInfo;
     public MarriageInfo MarriageInfo;
     public readonly Dictionary<int, DungeonEnterLimit> DungeonEnterLimits = [];
+    public short DeathCount;
+    public long DeathTick;
+    public DeathState DeathState;
     public long PremiumTime;
 }

--- a/Maple2.Model/Game/User/IPlayerInfo.cs
+++ b/Maple2.Model/Game/User/IPlayerInfo.cs
@@ -18,6 +18,7 @@ public interface IPlayerInfo {
     // Health
     public long CurrentHp { get; set; }
     public long TotalHp { get; set; }
+    public DeathState DeathState { get; set; }
     // Location
     public int MapId { get; set; }
     public short Channel { get; set; }

--- a/Maple2.Model/Game/User/PlayerInfo.cs
+++ b/Maple2.Model/Game/User/PlayerInfo.cs
@@ -62,9 +62,9 @@ public class PlayerInfo : CharacterInfo, IPlayerInfo, IByteSerializable {
         writer.WriteShort(Channel);
         writer.WriteInt((int) Job.Code());
         writer.Write<Job>(Job);
-        writer.WriteInt((int) CurrentHp);
         writer.WriteInt((int) TotalHp);
-        writer.WriteShort();
+        writer.WriteInt((int) CurrentHp);
+        writer.Write<DeathState>(DeathState);
         writer.WriteLong();
         writer.WriteLong(); // Home Storage Access Time
         writer.WriteLong(); // Home Doctor Access Time
@@ -123,6 +123,7 @@ public class CharacterInfo {
     // Health
     public long CurrentHp { get; set; }
     public long TotalHp { get; set; }
+    public DeathState DeathState { get; set; }
     // Location
     public int MapId { get; set; }
     public short Channel { get; set; }

--- a/Maple2.Model/Metadata/BeginCondition.cs
+++ b/Maple2.Model/Metadata/BeginCondition.cs
@@ -13,6 +13,7 @@ public record BeginCondition(
     float CooldownTime,
     bool OnlyShadowWorld,
     bool OnlyFlyableMap,
+    bool AllowDead,
     IReadOnlyDictionary<BasicAttribute, long> Stat,
     BeginConditionWeapon[]? Weapon,
     BeginConditionTarget? Target,

--- a/Maple2.Model/Metadata/Constants.cs
+++ b/Maple2.Model/Metadata/Constants.cs
@@ -928,6 +928,8 @@ public static class Constant {
     public const int NextStateTriggerDefaultTick = 100;
     public const int UserRevivalPaneltyTick = 3600000;
     public const int UserRevivalPaneltyMinLevel = 10;
+    public const int maxDeadCount = 3;
+    public const byte hitPerDeadCount = 5;
     public const int FishFightingProp = 3000;
 
     public const float NpcLastSightRadius = 1800;

--- a/Maple2.Model/Metadata/MapMetadata.cs
+++ b/Maple2.Model/Metadata/MapMetadata.cs
@@ -49,7 +49,7 @@ public record MapMetadataProperty(
     int TutorialType,
     int RevivalReturnId,
     int EnterReturnId,
-    int AutoRevivalType,
+    AutoReviveType AutoRevivalType,
     int AutoRevivalTime,
     bool InfiniteMeretRevival,
     bool NoRevivalHere,

--- a/Maple2.Model/Metadata/ServerTable/JobConditionTable.cs
+++ b/Maple2.Model/Metadata/ServerTable/JobConditionTable.cs
@@ -26,4 +26,5 @@ public record JobConditionMetadata(
     JobCode ChangeToJobCode,
     int MapId,
     int MoveMapId,
+    bool DeathPenalty,
     int MovePortalId);

--- a/Maple2.Model/Metadata/ServerTable/ScriptConditionTable.cs
+++ b/Maple2.Model/Metadata/ServerTable/ScriptConditionTable.cs
@@ -21,6 +21,7 @@ public record ScriptConditionMetadata(
     KeyValuePair<int, bool> Meso,
     KeyValuePair<int, bool> Level,
     KeyValuePair<int, bool> AchieveCompleted,
+    bool DeathPenalty,
     bool InGuild) {
 
     public record MaidData(

--- a/Maple2.Server.Core/Sync/PlayerInfoUpdateEvent.cs
+++ b/Maple2.Server.Core/Sync/PlayerInfoUpdateEvent.cs
@@ -19,12 +19,13 @@ public enum UpdateField {
     PremiumTime = 512,
     Clubs = 1024,
     Dungeon = 2048,
+    Death = 4096,
 
     // Presets
     Buddy = Profile | Job | Level | Map | Channel | Home | Trophy,
     Guild = Profile | Job | Level | GearScore | Map | Channel | Home | Trophy | Clubs,
     Club = Profile | Job | Level | GearScore | Map | Channel | Home | Trophy | Clubs,
-    Party = Profile | Job | Level | GearScore | Health | Map | Channel | Home | Clubs | Dungeon,
+    Party = Profile | Job | Level | GearScore | Health | Map | Channel | Home | Clubs | Dungeon | Death,
     GroupChat = Profile | Job | Level | Map | Channel | Home | Clubs,
     Marriage = Profile,
     All = int.MaxValue,
@@ -77,6 +78,9 @@ public class PlayerInfoUpdateEvent {
                 Type |= UpdateField.Health;
             }
         }
+        if (request.HasDeathState && player.DeathState != (DeathState) request.DeathState) {
+            Type |= UpdateField.Death;
+        }
         if (request.Home != null) {
             if (player.PlotMapId != request.Home.MapId) {
                 Type |= UpdateField.Home;
@@ -106,13 +110,13 @@ public class PlayerInfoUpdateEvent {
             }
         }
 
-        if (request.Clubs != null) {
+        if (request.Clubs.Count > 0) {
             if (player.ClubIds != request.Clubs.Select(club => club.Id).ToList()) {
                 Type |= UpdateField.Clubs;
             }
         }
 
-        if (request.DungeonEnterLimits != null) {
+        if (request.DungeonEnterLimits.Count > 0) {
             if (player.DungeonEnterLimits != request.DungeonEnterLimits.Select(dungeon => new KeyValuePair<int, DungeonEnterLimit>(dungeon.DungeonId, (DungeonEnterLimit) dungeon.Limit)).ToDictionary()) {
                 Type |= UpdateField.Dungeon;
             }

--- a/Maple2.Server.Core/Sync/PlayerInfoUpdateExtensions.cs
+++ b/Maple2.Server.Core/Sync/PlayerInfoUpdateExtensions.cs
@@ -48,6 +48,9 @@ public static class PlayerInfoUpdateExtensions {
             info.CurrentHp = update.Request.Health.CurrentHp;
             info.TotalHp = update.Request.Health.TotalHp;
         }
+        if (update.Type.HasFlag(UpdateField.Death) && update.Request.HasDeathState) {
+            info.DeathState = (DeathState) update.Request.DeathState;
+        }
         if (update.Type.HasFlag(UpdateField.Home) && update.Request.Home != null) {
             info.HomeName = update.Request.Home.Name;
             info.PlotMapId = update.Request.Home.MapId;
@@ -102,6 +105,9 @@ public static class PlayerInfoUpdateExtensions {
             self.CurrentHp = other.CurrentHp;
             self.TotalHp = other.TotalHp;
         }
+        if (type.HasFlag(UpdateField.Death)) {
+            self.DeathState = other.DeathState;
+        }
         if (type.HasFlag(UpdateField.Home)) {
             self.HomeName = other.HomeName;
             self.PlotMapId = other.PlotMapId;
@@ -155,6 +161,9 @@ public static class PlayerInfoUpdateExtensions {
                 CurrentHp = info.CurrentHp,
                 TotalHp = info.TotalHp,
             };
+        }
+        if (type.HasFlag(UpdateField.Death)) {
+            request.DeathState = (int) info.DeathState;
         }
         if (type.HasFlag(UpdateField.Home)) {
             request.Home = new HomeUpdate {

--- a/Maple2.Server.Core/proto/sync.proto
+++ b/Maple2.Server.Core/proto/sync.proto
@@ -65,9 +65,10 @@ message PlayerUpdateRequest {
   optional TrophyUpdate trophy = 19;
   repeated ClubUpdate clubs = 20;
   repeated DungeonEnterLimitUpdate dungeon_enter_limits = 21;
+  optional int32 death_state = 22;
 
   // Batch updates in a queue rather than immediately forwarding.
-  bool async = 22;
+  bool async = 23;
 }
 
 message PlayerUpdateResponse {
@@ -100,4 +101,5 @@ message PlayerInfoResponse {
   TrophyUpdate trophy = 19;
   repeated ClubUpdate clubs = 20;
   repeated DungeonEnterLimitUpdate dungeon_enter_limits = 21;
+  int32 death_state = 22;
 }

--- a/Maple2.Server.Core/proto/world/world.proto
+++ b/Maple2.Server.Core/proto/world/world.proto
@@ -528,12 +528,13 @@ message PlayerConfigRequest {
   message Save {
     repeated BuffInfo buffs = 1;
     repeated SkillCooldownInfo skill_cooldowns = 2;
+    DeathInfo death_info = 3;
   }
 
   message Get { }
 
   int64 requester_id = 1;
-  oneof buff {
+  oneof player_config {
     Save save = 2;
     Get get = 3;
   }
@@ -542,6 +543,7 @@ message PlayerConfigRequest {
 message PlayerConfigResponse {
   repeated BuffInfo buffs = 1;
   repeated SkillCooldownInfo skill_cooldowns = 2;
+  DeathInfo death_info = 3;
 }
 
 message BuffInfo {
@@ -560,4 +562,10 @@ message SkillCooldownInfo {
   int32 ms_remaining = 4;
   int64 stop_time = 5;
   int32 charges = 6;
+}
+
+message DeathInfo {
+  int32 count = 1;
+  int32 ms_remaining = 2;
+  int64 stop_time = 3;
 }

--- a/Maple2.Server.Game/Commands/KillCommand.cs
+++ b/Maple2.Server.Game/Commands/KillCommand.cs
@@ -131,8 +131,12 @@ public class KillCommand : Command {
                 return;
             }
 
-            player.Stats.Values[BasicAttribute.Health].Add(-player.Stats.Values[BasicAttribute.Health].Current);
-            player.Session.Send(StatsPacket.Update(player, BasicAttribute.Health));
+            if (player.DeathState != DeathState.Alive) {
+                ctx.Console.Out.WriteLine($"Player {name} is already dead.");
+                return;
+            }
+
+            player.ConsumeHp((int) player.Stats.Values[BasicAttribute.Health].Current);
         }
     }
 

--- a/Maple2.Server.Game/Manager/Config/BuffManager.cs
+++ b/Maple2.Server.Game/Manager/Config/BuffManager.cs
@@ -413,7 +413,9 @@ public class BuffManager : IUpdatable {
         foreach (Buff buff in Buffs.Values) {
             if (!buff.Metadata.Property.KeepOnDeath) {
                 Remove(buff.Id);
+                continue;
             }
+            buff.UpdateEnabled();
         }
     }
 
@@ -429,5 +431,11 @@ public class BuffManager : IUpdatable {
 
     public List<Buff> GetSaveCacheBuffs() {
         return Buffs.Values.Where(buff => !buff.Metadata.Property.RemoveOnLogout).ToList();
+    }
+
+    public void UpdateEnabled() {
+        foreach (Buff buff in Buffs.Values) {
+            buff.UpdateEnabled();
+        }
     }
 }

--- a/Maple2.Server.Game/Manager/Config/ConfigManager.cs
+++ b/Maple2.Server.Game/Manager/Config/ConfigManager.cs
@@ -1,4 +1,4 @@
-﻿﻿using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using Maple2.Database.Extensions;
 using Maple2.Database.Storage;
 using Maple2.Model.Enum;
@@ -6,7 +6,6 @@ using Maple2.Model.Game;
 using Maple2.Model.Metadata;
 using Maple2.Server.Core.Packets;
 using Maple2.Server.Game.Manager.Items;
-using Maple2.Server.Game.Model;
 using Maple2.Server.Game.Packets;
 using Maple2.Server.Game.Session;
 using Maple2.Server.World.Service;
@@ -27,8 +26,14 @@ public class ConfigManager {
     private readonly IList<long> favoriteDesigners;
     private readonly IDictionary<LapenshardSlot, int> lapenshards;
     private readonly IDictionary<int, SkillCooldown> skillCooldowns;
-    public long DeathPenaltyEndTick;
-    public int DeathCount;
+    public long DeathPenaltyEndTick {
+        get => session.Player.Value.Character.DeathTick;
+        private set => session.Player.Value.Character.DeathTick = value;
+    }
+    public short DeathCount {
+        get => session.Player.Value.Character.DeathCount;
+        private set => session.Player.Value.Character.DeathCount = value;
+    }
     public int InstantReviveCount;
     private readonly StatAttributes statAttributes;
     private readonly SkillPoint skillPoints;
@@ -340,7 +345,7 @@ public class ConfigManager {
 
     public void SetDeathPenalty(DeathInfo deathInfo, long currentTick) {
         DeathPenaltyEndTick = currentTick + deathInfo.MsRemaining;
-        DeathCount = deathInfo.Count;
+        DeathCount = (short) deathInfo.Count;
     }
 
     public void AddInstantReviveCount(int count = 1) {

--- a/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.State.cs
+++ b/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.State.cs
@@ -83,15 +83,10 @@ public partial class FieldManager {
 
         // Use SpawnPoint if needed.
         if (fieldPlayer.Position == default) {
-            FieldPlayerSpawnPoint? spawn = fieldPlayerSpawnPoints.Values.FirstOrDefault(spawn => spawn.Enable);
-            if (spawn != null) {
+            if (TryGetPlayerSpawn(-1, out FieldPlayerSpawnPoint? spawn)) {
                 fieldPlayer.Position = spawn.Position + new Vector3(0, 0, 25);
                 fieldPlayer.Rotation = spawn.Rotation;
             }
-        }
-
-        if (Metadata.Property.RevivalReturnId != 0) {
-            player.Character.ReviveMapId = Metadata.Property.RevivalReturnId;
         }
 
         if (FieldInstance.Type == InstanceType.none || FieldInstance.SaveField) {
@@ -780,6 +775,8 @@ public partial class FieldManager {
             }
         }
         Broadcast(FieldPacket.AddPlayer(added.Session), added.Session);
+        added.Flag = PlayerObjectFlag.All;
+
         Broadcast(ProxyObjectPacket.AddPlayer(added), added.Session);
         foreach (FieldItem fieldItem in fieldItems.Values) {
             added.Session.Send(FieldPacket.DropItem(fieldItem));

--- a/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.cs
+++ b/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.cs
@@ -389,6 +389,12 @@ public partial class FieldManager : IField {
     }
 
     public bool TryGetPlayerSpawn(int id, [NotNullWhen(true)] out FieldPlayerSpawnPoint? playerSpawnPoint) {
+        // Get random spawn point if id is -1
+        if (id < 0) {
+            List<FieldPlayerSpawnPoint> enabledSpawns = fieldPlayerSpawnPoints.Values.Where(spawn => spawn.Enable).ToList();
+            playerSpawnPoint = enabledSpawns.Count > 0 ? enabledSpawns[Random.Shared.Next(enabledSpawns.Count)] : null;
+            return playerSpawnPoint != null;
+        }
         return fieldPlayerSpawnPoints.TryGetValue(id, out playerSpawnPoint);
     }
 

--- a/Maple2.Server.Game/Manager/PartyManager.cs
+++ b/Maple2.Server.Game/Manager/PartyManager.cs
@@ -362,7 +362,7 @@ public class PartyManager : IDisposable {
 
         member.Info.Update(type, info);
 
-        if (type == UpdateField.Health || type == UpdateField.Level) {
+        if (type is UpdateField.Health or UpdateField.Death) {
             session.Send(PartyPacket.UpdateStats(member));
         } else {
             session.Send(PartyPacket.Update(member));

--- a/Maple2.Server.Game/Manager/StatsManager.cs
+++ b/Maple2.Server.Game/Manager/StatsManager.cs
@@ -122,6 +122,16 @@ public class StatsManager {
         StatConversion(player);
         Actor.Field.Broadcast(StatsPacket.Init(player));
         Actor.Field.Broadcast(StatsPacket.Update(player), player.Session);
+
+        player.Session.PlayerInfo.SendUpdate(new PlayerUpdateRequest {
+            AccountId = player.Session.AccountId,
+            CharacterId = player.Session.CharacterId,
+            Health = new HealthUpdate {
+                CurrentHp = Values[BasicAttribute.Health].Current,
+                TotalHp = Values[BasicAttribute.Health].Total,
+            },
+            Async = true,
+        });
     }
 
     public void ResetActor(IActor actor) {

--- a/Maple2.Server.Game/Model/Field/Buff.cs
+++ b/Maple2.Server.Game/Model/Field/Buff.cs
@@ -103,7 +103,7 @@ public class Buff : IUpdatable, IByteSerializable {
         Proc();
     }
 
-    private bool UpdateEnabled(bool notifyField = true) {
+    public bool UpdateEnabled(bool notifyField = true) {
         bool enabled = Metadata.Condition.Check(Caster, Owner, Owner);
         if (Enabled != enabled) {
             Enabled = enabled;

--- a/Maple2.Server.Game/Model/Field/Tombstone.cs
+++ b/Maple2.Server.Game/Model/Field/Tombstone.cs
@@ -1,0 +1,39 @@
+﻿using Maple2.Model.Metadata;
+using Maple2.PacketLib.Tools;
+using Maple2.Server.Game.Packets;
+using Maple2.Tools;
+
+namespace Maple2.Server.Game.Model;
+
+public class Tombstone : IByteSerializable {
+    public readonly FieldPlayer Owner;
+    public int ObjectId => Owner.ObjectId;
+    private byte hitsRemaining;
+    public byte HitsRemaining {
+        get => hitsRemaining;
+        set {
+            if (hitsRemaining == 0 || value == 0) {
+                return;
+            }
+            hitsRemaining = Math.Clamp(value, (byte) 0, TotalHitCount);
+
+            Owner.Field.Broadcast(RevivalPacket.Tombstone(this));
+        }
+    }
+    public byte TotalHitCount { get; }
+    public int Unknown1 { get; } = 1;
+    public bool Unknown2 { get; }
+
+    public Tombstone(FieldPlayer owner, int totalDeaths) {
+        Owner = owner;
+        TotalHitCount = (byte) Math.Min(totalDeaths * Constant.hitPerDeadCount, Constant.hitPerDeadCount * Constant.maxDeadCount);
+        hitsRemaining = TotalHitCount;
+    }
+    public void WriteTo(IByteWriter writer) {
+        writer.WriteInt(ObjectId);
+        writer.WriteByte(HitsRemaining);
+        writer.WriteByte(TotalHitCount);
+        writer.WriteInt(Unknown1); // 1 if hit by a user?
+        writer.WriteBool(Unknown2); // true if revived by pet
+    }
+}

--- a/Maple2.Server.Game/Model/Field/Tombstone.cs
+++ b/Maple2.Server.Game/Model/Field/Tombstone.cs
@@ -12,7 +12,7 @@ public class Tombstone : IByteSerializable {
     public byte HitsRemaining {
         get => hitsRemaining;
         set {
-            if (hitsRemaining == 0 || value == 0) {
+            if (hitsRemaining == 0) {
                 return;
             }
             hitsRemaining = Math.Clamp(value, (byte) 0, TotalHitCount);

--- a/Maple2.Server.Game/PacketHandlers/HomeDoctorHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/HomeDoctorHandler.cs
@@ -4,7 +4,6 @@ using Maple2.PacketLib.Tools;
 using Maple2.Server.Core.Constants;
 using Maple2.Server.Core.PacketHandlers;
 using Maple2.Server.Core.Packets;
-using Maple2.Server.Game.Packets;
 using Maple2.Server.Game.Session;
 
 namespace Maple2.Server.Game.PacketHandlers;
@@ -22,7 +21,7 @@ public class HomeDoctorHandler : PacketHandler<GameSession> {
             return;
         }
 
-        int cost =session.Field.Lua.CalcResolvePenaltyPrice((ushort) session.Player.Value.Character.Level, session.Config.DeathCount, 0);
+        int cost = session.Field.Lua.CalcResolvePenaltyPrice((ushort) session.Player.Value.Character.Level, session.Config.DeathCount, 0);
         if (session.Currency.Meso < cost) {
             return;
         }

--- a/Maple2.Server.Game/PacketHandlers/ResolveDeathPenaltyHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/ResolveDeathPenaltyHandler.cs
@@ -21,7 +21,7 @@ public class ResolveDeathPenaltyHandler : PacketHandler<GameSession> {
         }
 
         int mode = session.Field.Metadata.Property.Continent == Continent.ShadowWorld ? 1 : 0;
-        int cost =session.Field.Lua.CalcResolvePenaltyPrice((ushort) session.Player.Value.Character.Level, session.Config.DeathCount, mode);
+        int cost = session.Field.Lua.CalcResolvePenaltyPrice((ushort) session.Player.Value.Character.Level, session.Config.DeathCount, mode);
         if (session.Currency.Meso < cost) {
             return;
         }

--- a/Maple2.Server.Game/PacketHandlers/ResolveDeathPenaltyHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/ResolveDeathPenaltyHandler.cs
@@ -1,0 +1,33 @@
+﻿using Maple2.Model.Enum;
+using Maple2.PacketLib.Tools;
+using Maple2.Server.Core.Constants;
+using Maple2.Server.Core.PacketHandlers;
+using Maple2.Server.Game.Model;
+using Maple2.Server.Game.Session;
+
+namespace Maple2.Server.Game.PacketHandlers;
+
+public class ResolveDeathPenaltyHandler : PacketHandler<GameSession> {
+    public override RecvOp OpCode => RecvOp.ResolvePenalty;
+
+    public override void Handle(GameSession session, IByteReader packet) {
+        int npcObjectId = packet.ReadInt();
+        if (!session.Field.Npcs.TryGetValue(npcObjectId, out FieldNpc? npc) || npc.Value.Metadata.Basic.Kind != 81) { // 81 = Doctor
+            return;
+        }
+
+        if (session.Config.DeathPenaltyEndTick < session.Field.FieldTick) {
+            return;
+        }
+
+        int mode = session.Field.Metadata.Property.Continent == Continent.ShadowWorld ? 1 : 0;
+        int cost =session.Field.Lua.CalcResolvePenaltyPrice((ushort) session.Player.Value.Character.Level, session.Config.DeathCount, mode);
+        if (session.Currency.Meso < cost) {
+            return;
+        }
+
+        session.Currency.Meso -= cost;
+        session.Config.UpdateDeathPenalty(0);
+        session.ConditionUpdate(ConditionType.resolve_panelty);
+    }
+}

--- a/Maple2.Server.Game/PacketHandlers/RevivalHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/RevivalHandler.cs
@@ -1,7 +1,9 @@
-﻿using Maple2.Model.Metadata;
+﻿﻿﻿﻿using Maple2.Model.Enum;
+using Maple2.Model.Game;
 using Maple2.PacketLib.Tools;
 using Maple2.Server.Core.Constants;
 using Maple2.Server.Core.PacketHandlers;
+using Maple2.Server.Core.Packets;
 using Maple2.Server.Game.Session;
 
 namespace Maple2.Server.Game.PacketHandlers;
@@ -26,13 +28,52 @@ public class RevivalHandler : PacketHandler<GameSession> {
         }
     }
 
+    /// <summary>
+    /// Handles normal revival (from tombstone hits or manual revival)
+    /// </summary>
     private void HandleSafeRevive(GameSession session) {
-        session.Config.UpdateDeathPenalty((int) (Environment.TickCount64 + TimeSpan.FromMilliseconds(Constant.UserRevivalPaneltyTick).TotalMilliseconds));
-        // send invincible buff?
-        // send player to a spawn point
+        if (session.Field.Metadata.Property.NoRevivalHere || session.Field.Metadata.Property.RevivalReturnId == 0) {
+            return;
+        }
+        // Revive player - this will handle moving to spawn point
+        if (session.Player.Revive()) {
+            session.Player.Tombstone = null;
+        }
     }
 
+    /// <summary>
+    /// Handles instant revival (using mesos or voucher)
+    /// </summary>
     private void HandleInstantRevive(GameSession session, IByteReader packet) {
+        if (session.Field.Metadata.Property.NoRevivalHere) {
+            return;
+        }
+
         bool useVoucher = packet.ReadBool();
+
+        if (useVoucher) {
+            if (!session.Item.Inventory.Consume([new IngredientInfo(ItemTag.FreeReviveCoupon, 1)])) {
+                // Send error packet?
+                return;
+            }
+            session.Send(NoticePacket.Notice(NoticePacket.Flags.Alert | NoticePacket.Flags.Message, StringCode.s_revival_use_coupon));
+        } else {
+            int totalMaxCount = session.Field.Lua.GetMesoRevivalDailyMaxCount();
+            if (session.Config.InstantReviveCount >= totalMaxCount) {
+                return;
+            }
+
+            int cost = session.Field.Lua.CalcRevivalPrice((ushort) session.Player.Value.Character.Level);
+            if (session.Currency.Meso < cost) {
+                // Client sends error
+                return;
+            }
+            session.Currency.Meso -= cost;
+        }
+
+        session.Config.InstantReviveCount++;
+        if (session.Player.Revive(true)) {
+            session.Player.Tombstone = null;
+        }
     }
 }

--- a/Maple2.Server.Game/PacketHandlers/RevivalHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/RevivalHandler.cs
@@ -1,4 +1,4 @@
-﻿﻿﻿﻿using Maple2.Model.Enum;
+﻿using Maple2.Model.Enum;
 using Maple2.Model.Game;
 using Maple2.PacketLib.Tools;
 using Maple2.Server.Core.Constants;

--- a/Maple2.Server.Game/PacketHandlers/TombstoneHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/TombstoneHandler.cs
@@ -1,0 +1,22 @@
+﻿using Maple2.PacketLib.Tools;
+using Maple2.Server.Core.Constants;
+using Maple2.Server.Core.PacketHandlers;
+using Maple2.Server.Game.Model;
+using Maple2.Server.Game.Session;
+
+namespace Maple2.Server.Game.PacketHandlers;
+
+public class TombstoneHandler : PacketHandler<GameSession> {
+    public override RecvOp OpCode => RecvOp.Tombstone;
+
+    public override void Handle(GameSession session, IByteReader packet) {
+        int objectId = packet.ReadInt();
+        int hits = packet.ReadInt();
+
+        if (!session.Field.TryGetPlayer(objectId, out FieldPlayer? player) || player.Tombstone == null) {
+            return;
+        }
+
+        player.Tombstone.HitsRemaining -= (byte) hits;
+    }
+}

--- a/Maple2.Server.Game/PacketHandlers/TombstoneHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/TombstoneHandler.cs
@@ -1,4 +1,5 @@
-﻿using Maple2.PacketLib.Tools;
+﻿using Maple2.Model.Enum;
+using Maple2.PacketLib.Tools;
 using Maple2.Server.Core.Constants;
 using Maple2.Server.Core.PacketHandlers;
 using Maple2.Server.Game.Model;
@@ -18,5 +19,6 @@ public class TombstoneHandler : PacketHandler<GameSession> {
         }
 
         player.Tombstone.HitsRemaining -= (byte) hits;
+        session.ConditionUpdate(ConditionType.hit_tombstone);
     }
 }

--- a/Maple2.Server.Game/Packets/DeadUserPacket.cs
+++ b/Maple2.Server.Game/Packets/DeadUserPacket.cs
@@ -1,0 +1,15 @@
+﻿using Maple2.PacketLib.Tools;
+using Maple2.Server.Core.Constants;
+using Maple2.Server.Core.Packets;
+
+namespace Maple2.Server.Game.Packets;
+
+public static class DeadUserPacket {
+    public static ByteWriter Dead(int objectId, bool darkTombstone) {
+        var pWriter = Packet.Of(SendOp.DeadUser);
+        pWriter.WriteInt(objectId);
+        pWriter.WriteBool(darkTombstone);
+
+        return pWriter;
+    }
+}

--- a/Maple2.Server.Game/Packets/FieldPacket.cs
+++ b/Maple2.Server.Game/Packets/FieldPacket.cs
@@ -298,9 +298,9 @@ public static class FieldPacket {
         writer.WriteShort(character.Channel);
         writer.WriteInt((int) character.Job.Code());
         writer.Write<Job>(character.Job);
-        writer.WriteInt((int) session.Stats.Values[BasicAttribute.Health].Current);
         writer.WriteInt((int) session.Stats.Values[BasicAttribute.Health].Total);
-        writer.WriteShort();
+        writer.WriteInt((int) session.Stats.Values[BasicAttribute.Health].Current);
+        writer.WriteShort(character.DeathCount);
         writer.WriteLong();
         writer.WriteLong(character.StorageCooldown);
         writer.WriteLong(character.DoctorCooldown);

--- a/Maple2.Server.Game/Packets/PartyPacket.cs
+++ b/Maple2.Server.Game/Packets/PartyPacket.cs
@@ -6,7 +6,7 @@ using Maple2.Server.Core.Constants;
 using Maple2.Server.Core.Packets;
 using Maple2.Tools.Extensions;
 using Maple2.Model.Game.Party;
-using Maple2.Server.Game.Manager.Field;
+// ReSharper disable RedundantTypeArgumentsOfMethod
 
 namespace Maple2.Server.Game.Packets;
 
@@ -192,9 +192,9 @@ public static class PartyPacket {
 
         pWriter.WriteLong(member.CharacterId);
         pWriter.WriteLong(member.AccountId);
-        pWriter.WriteInt((int) member.Info.CurrentHp);
         pWriter.WriteInt((int) member.Info.TotalHp);
-        pWriter.WriteShort(member.Info.Level);
+        pWriter.WriteInt((int) member.Info.CurrentHp);
+        pWriter.Write<DeathState>(member.Info.DeathState);
 
         return pWriter;
     }
@@ -204,6 +204,7 @@ public static class PartyPacket {
         pWriter.Write<Command>(Command.DungeonNotice);
 
         pWriter.WriteUnicodeString(message.ToString());
+        // ReSharper disable once CommentTypo
         pWriter.WriteUnicodeString(systemSoundKey); // "Field_Enterance_Reset_Dungeon"
         pWriter.WriteUnicodeString();
 
@@ -243,6 +244,7 @@ public static class PartyPacket {
     public static ByteWriter PartySearch(byte type, bool searching) {
         var pWriter = Packet.Of(SendOp.Party);
         pWriter.Write<Command>(Command.PartySearch);
+        // ReSharper disable once CommentTypo
         /*
             if type == 1:
                 dungeon_message(1) # s_enum_dungeon_group_normal

--- a/Maple2.Server.Game/Packets/RevivalPacket.cs
+++ b/Maple2.Server.Game/Packets/RevivalPacket.cs
@@ -1,24 +1,39 @@
-﻿using Maple2.Model.Game;
-using Maple2.PacketLib.Tools;
+﻿using Maple2.PacketLib.Tools;
 using Maple2.Server.Core.Constants;
 using Maple2.Server.Core.Packets;
 using Maple2.Server.Game.Model;
+using Maple2.Tools.Extensions;
 
 namespace Maple2.Server.Game.Packets;
 
 public static class RevivalPacket {
-    public static ByteWriter Confirm(IActor<Player> player, int ticks = 0, int counter = 0) {
+    public static ByteWriter UpdatePenalty(int objectId, int endTick, int count) {
         var pWriter = Packet.Of(SendOp.RevivalConfirm);
-        pWriter.WriteInt(player.ObjectId);
-        pWriter.WriteInt(ticks); // 0 in house
-        pWriter.WriteInt(counter); // (some counter); 0 in house
+        pWriter.WriteInt(objectId);
+        pWriter.WriteInt(endTick);
+        pWriter.WriteInt(count);
 
         return pWriter;
     }
 
-    public static ByteWriter Count(int count) {
+    public static ByteWriter RevivalCount(int count) {
         var pWriter = Packet.Of(SendOp.RevivalCount);
         pWriter.WriteInt(count);
+
+        return pWriter;
+    }
+
+    public static ByteWriter Revive(int objectId) {
+        var pWriter = Packet.Of(SendOp.Revival);
+        pWriter.WriteInt(objectId);
+        pWriter.WriteByte();
+
+        return pWriter;
+    }
+
+    public static ByteWriter Tombstone(Tombstone tombstone) {
+        var pWriter = Packet.Of(SendOp.Tombstone);
+        pWriter.WriteClass<Tombstone>(tombstone);
 
         return pWriter;
     }

--- a/Maple2.Server.Game/Session/GameSession.cs
+++ b/Maple2.Server.Game/Session/GameSession.cs
@@ -426,6 +426,7 @@ public sealed partial class GameSession : Core.Network.Session {
         Send(StatsPacket.Init(Player));
         Field.Broadcast(StatsPacket.Update(Player), Player.Session);
 
+        //TODO: Save current hp/sp/ep in memory. This will help determine if player is dead upon login.
         var pWriter = Packet.Of(SendOp.UserState);
         pWriter.WriteInt(Player.ObjectId);
         pWriter.Write<ActorState>(ActorState.Fall);

--- a/Maple2.Server.Game/Session/GameSession.cs
+++ b/Maple2.Server.Game/Session/GameSession.cs
@@ -255,6 +255,7 @@ public sealed partial class GameSession : Core.Network.Session {
             long currentTick = Environment.TickCount64;
             Buffs.SetCacheBuffs(configResponse.Buffs, currentTick);
             Config.SetCacheSkillCooldowns(configResponse.SkillCooldowns, currentTick);
+            Config.SetDeathPenalty(configResponse.DeathInfo, currentTick);
 
         } catch (RpcException ex) {
             Logger.Warning(ex, "Failed to load cache player config");
@@ -441,8 +442,7 @@ public sealed partial class GameSession : Core.Network.Session {
         Send(CubePacket.ReturnMap(Player.Value.Character.ReturnMapId));
 
         Config.LoadLapenshard();
-        Send(RevivalPacket.Count(0)); // TODO: Consumed daily revivals?
-        Send(RevivalPacket.Confirm(Player));
+        Config.LoadRevival();
         Config.LoadStatAttributes();
         Config.LoadSkillPoints();
         Player.Buffs.LoadFieldBuffs();
@@ -601,8 +601,7 @@ public sealed partial class GameSession : Core.Network.Session {
         Config.GatheringCounts.Clear();
         Send(UserEnvPacket.GatheringCounts(Config.GatheringCounts));
         // Death Counter
-        Config.DeathCount = 0;
-        Send(RevivalPacket.Count(0));
+        Config.AddInstantReviveCount(-1);
         // Premium Rewards Claimed
         Player.Value.Account.PremiumRewardsClaimed.Clear();
         Send(PremiumCubPacket.LoadItems(Player.Value.Account.PremiumRewardsClaimed));
@@ -785,6 +784,11 @@ public sealed partial class GameSession : Core.Network.Session {
                                 StopTime = stopTime,
                                 Charges = cooldown.Charges,
                             }),
+                        },
+                        DeathInfo = new DeathInfo {
+                            Count = Config.DeathCount,
+                            MsRemaining = (int) (Config.DeathPenaltyEndTick - fieldTick),
+                            StopTime = stopTime,
                         },
                     },
                     RequesterId = CharacterId,

--- a/Maple2.Server.Game/Util/ConditionUtil.cs
+++ b/Maple2.Server.Game/Util/ConditionUtil.cs
@@ -159,6 +159,9 @@ public static class ConditionUtil {
             case ConditionType.wedding_propose_declined:
             case ConditionType.wedding_hall_cancel:
             case ConditionType.item_gear_score:
+            case ConditionType.revival:
+            case ConditionType.home_doctor:
+            case ConditionType.resolve_panelty:
                 return true;
         }
         return false;
@@ -288,6 +291,9 @@ public static class ConditionUtil {
             case ConditionType.continent:
             case ConditionType.explore:
             case ConditionType.item_gear_score:
+            case ConditionType.revival:
+            case ConditionType.home_doctor:
+            case ConditionType.resolve_panelty:
                 return true;
         }
         return false;

--- a/Maple2.Server.Game/Util/ConditionUtil.cs
+++ b/Maple2.Server.Game/Util/ConditionUtil.cs
@@ -162,6 +162,7 @@ public static class ConditionUtil {
             case ConditionType.revival:
             case ConditionType.home_doctor:
             case ConditionType.resolve_panelty:
+            case ConditionType.hit_tombstone:
                 return true;
         }
         return false;
@@ -294,6 +295,7 @@ public static class ConditionUtil {
             case ConditionType.revival:
             case ConditionType.home_doctor:
             case ConditionType.resolve_panelty:
+            case ConditionType.hit_tombstone:
                 return true;
         }
         return false;

--- a/Maple2.Server.Game/Util/NpcTalkUtil.cs
+++ b/Maple2.Server.Game/Util/NpcTalkUtil.cs
@@ -131,6 +131,10 @@ public static class NpcTalkUtil {
             return false;
         }
 
+        if (jobCondition.DeathPenalty && session.Config.DeathPenaltyEndTick < session.Field.FieldTick) {
+            return false;
+        }
+
         return true;
     }
 
@@ -210,6 +214,10 @@ public static class NpcTalkUtil {
         }
 
         if (scriptCondition.InGuild && session.Player.Value.Character.GuildId == 0) {
+            return false;
+        }
+
+        if (scriptCondition.DeathPenalty && session.Config.DeathPenaltyEndTick < session.Field.FieldTick) {
             return false;
         }
 

--- a/Maple2.Server.Game/Util/SkillUtils.cs
+++ b/Maple2.Server.Game/Util/SkillUtils.cs
@@ -72,6 +72,9 @@ public static class SkillUtils {
             if (condition is not { Probability: 1 } && condition.Probability < Random.Shared.NextDouble()) {
                 return false;
             }
+            if (!condition.AllowDead && caster.IsDead) {
+                return false;
+            }
             if (condition.OnlyShadowWorld && caster.Field.Metadata.Property.Type != MapType.Shadow) {
                 return false;
             }

--- a/Maple2.Server.World/Migrations/20250406064924_DeathCount.Designer.cs
+++ b/Maple2.Server.World/Migrations/20250406064924_DeathCount.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Maple2.Database.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Maple2.Server.World.Migrations
 {
     [DbContext(typeof(Ms2Context))]
-    partial class Ms2ContextModelSnapshot : ModelSnapshot
+    [Migration("20250406064924_DeathCount")]
+    partial class DeathCount
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Maple2.Server.World/Migrations/20250406064924_DeathCount.cs
+++ b/Maple2.Server.World/Migrations/20250406064924_DeathCount.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Maple2.Server.World.Migrations
+{
+    /// <inheritdoc />
+    public partial class DeathCount : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DeathTick",
+                table: "character-config");
+
+            migrationBuilder.RenameColumn(
+                name: "DeathCount",
+                table: "character-config",
+                newName: "InstantRevivalCount");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "InstantRevivalCount",
+                table: "character-config",
+                newName: "DeathCount");
+
+            migrationBuilder.AddColumn<long>(
+                name: "DeathTick",
+                table: "character-config",
+                type: "bigint",
+                nullable: false,
+                defaultValue: 0L);
+        }
+    }
+}

--- a/Maple2.Server.World/Service/WorldService.PlayerConfig.cs
+++ b/Maple2.Server.World/Service/WorldService.PlayerConfig.cs
@@ -5,10 +5,10 @@ namespace Maple2.Server.World.Service;
 
 public partial class WorldService {
     public override Task<PlayerConfigResponse> PlayerConfig(PlayerConfigRequest request, ServerCallContext context) {
-        switch (request.BuffCase) {
-            case PlayerConfigRequest.BuffOneofCase.Get:
+        switch (request.PlayerConfigCase) {
+            case PlayerConfigRequest.PlayerConfigOneofCase.Get:
                 return Task.FromResult(Get(request.Get, request.RequesterId));
-            case PlayerConfigRequest.BuffOneofCase.Save:
+            case PlayerConfigRequest.PlayerConfigOneofCase.Save:
                 return Task.FromResult(Save(request.Save, request.RequesterId));
             default:
                 return Task.FromResult(new PlayerConfigResponse());
@@ -16,7 +16,7 @@ public partial class WorldService {
     }
 
     private PlayerConfigResponse Get(PlayerConfigRequest.Types.Get get, long requesterId) {
-        (List<BuffInfo> buffs, List<SkillCooldownInfo> skillCooldowns) = playerConfigLookUp.Retrieve(requesterId);
+        (List<BuffInfo> buffs, List<SkillCooldownInfo> skillCooldowns, DeathInfo death) = playerConfigLookUp.Retrieve(requesterId);
         return new PlayerConfigResponse {
             Buffs = {
                 buffs.Select(b => new BuffInfo {
@@ -38,11 +38,12 @@ public partial class WorldService {
                     Charges = c.Charges,
                 }),
             },
+            DeathInfo = death,
         };
     }
 
     private PlayerConfigResponse Save(PlayerConfigRequest.Types.Save save, long requesterId) {
-        playerConfigLookUp.Save(save.Buffs.ToList(), save.SkillCooldowns.ToList(), requesterId);
+        playerConfigLookUp.Save(save.Buffs.ToList(), save.SkillCooldowns.ToList(), save.DeathInfo, requesterId);
         return new PlayerConfigResponse();
     }
 }

--- a/Maple2.Server.World/Service/WorldService.Sync.cs
+++ b/Maple2.Server.World/Service/WorldService.Sync.cs
@@ -36,6 +36,7 @@ public partial class WorldService {
                 CurrentHp = info.CurrentHp,
                 TotalHp = info.TotalHp,
             },
+            DeathState = (int) info.DeathState,
             GuildName = info.GuildName,
             GuildId = info.GuildId,
             Home = new HomeUpdate {


### PR DESCRIPTION
- Implements Death & Revival
- Added Kill command to player
- Implemented field & home doctor death penalty removal
- Implemented 4 condition types:
   - resolve_panelty
   - home_doctor
   - revival
   - hit_tombstone
- implementing player death to memory
- Updated buffs upon death/revival

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Revamped death and revival mechanics with dynamic penalty adjustments and an instant revival counter for a more balanced gameplay experience.
  - Introduced tombstone interactions that provide visual feedback and enhanced recovery options after death.
  - Enabled targeted player actions via an updated kill command.
  - Improved real-time updates to party and character status with refined death state tracking, including dynamic home doctor pricing for revival services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->