### PR TITLE
Fix AttendGift Packet

### DIFF
--- a/Maple2.File.Ingest/Mapper/ServerTableMapper.cs
+++ b/Maple2.File.Ingest/Mapper/ServerTableMapper.cs
@@ -414,7 +414,7 @@ public class ServerTableMapper : TypeMapper<ServerTableMetadata> {
                 Id: id,
                 ConsumeItem: new ItemComponent(
                     ItemId: bonusGame.consumeItemID,
-                    Rarity: -1,
+                    Rarity: 1,
                     Amount: bonusGame.consumeItemCount,
                     Tag: ItemTag.None),
                 Slots: slots.ToArray()));
@@ -779,6 +779,12 @@ public class ServerTableMapper : TypeMapper<ServerTableMetadata> {
 
             DateTime startTime = DateTime.TryParseExact(data.eventStart, "yyyy-MM-dd-HH-mm", CultureInfo.InvariantCulture, DateTimeStyles.None, out startTime) ? startTime : DateTime.MinValue;
             DateTime endTime = DateTime.TryParseExact(data.eventEnd, "yyyy-MM-dd-HH-mm", CultureInfo.InvariantCulture, DateTimeStyles.None, out endTime) ? endTime : DateTime.MinValue;
+
+            // Only add events that are not expired
+            if (endTime < DateTime.UtcNow) {
+                continue;
+            }
+
             (TimeSpan partTimeStart, TimeSpan partTimeEnd) = ParsePartTime(data.partTime);
             results.Add(id, new GameEventMetadata(
                 Id: id,
@@ -865,7 +871,7 @@ public class ServerTableMapper : TypeMapper<ServerTableMetadata> {
                             RoundCount: round,
                             Item: new ItemComponent(
                                 ItemId: itemId,
-                                Rarity: -1,
+                                Rarity: 1,
                                 Amount: itemCount,
                                 Tag: ItemTag.None)));
                     }

--- a/Maple2.Model/Game/Event/GameEvent.cs
+++ b/Maple2.Model/Game/Event/GameEvent.cs
@@ -90,17 +90,23 @@ public class GameEvent : IByteSerializable {
                 writer.WriteLong(EndTime);
                 writer.WriteUnicodeString(attendGift.Name);
                 writer.WriteString(attendGift.Link);
+                writer.WriteByte();
                 writer.WriteBool(true); // disable claim button
                 writer.WriteInt(attendGift.RequiredPlaySeconds);
                 writer.WriteByte();
                 writer.WriteInt();
+
                 var currencyType = AttendGiftCurrencyType.None;
                 writer.Write<AttendGiftCurrencyType>(currencyType);
-
                 if (currencyType != AttendGiftCurrencyType.None) {
                     writer.WriteInt(); // Skip Days Allowed
                     writer.WriteLong(); // Skip Day Cost
                     writer.WriteInt();
+                }
+
+                writer.WriteInt(attendGift.Items.Length);
+                foreach (RewardItem item in attendGift.Items) {
+                    writer.Write<RewardItem>(item);
                 }
                 break;
             case MeretMarketNotice notice:


### PR DESCRIPTION
Fix: BlueMarble and BonusGameTable default item rarity
Feat: Only add events that are not expired

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expired game events are now automatically excluded from event listings.
  - Attendance gift rewards are now explicitly displayed, showing detailed reward items.

- **Bug Fixes**
  - Corrected item rarity values for certain bonus games and BlueMarble event rounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->