### PR TITLE
Adjust Field Instancing & Vibrate Cubes

### DIFF
--- a/Maple2.File.Ingest/Mapper/ItemMapper.cs
+++ b/Maple2.File.Ingest/Mapper/ItemMapper.cs
@@ -19,7 +19,6 @@ public class ItemMapper : TypeMapper<ItemMetadata> {
     }
 
     protected override IEnumerable<ItemMetadata> Map() {
-        IEnumerable<(int Id, ItemExtraction Extraction)> itemExtractionData = tableParser.ParseItemExtraction();
         Dictionary<int, int> itemExtractionTryCount = tableParser.ParseItemExtraction()
             .ToDictionary(entry => entry.Id, entry => entry.Extraction.TryCount);
 

--- a/Maple2.File.Ingest/Mapper/MapDataMapper.cs
+++ b/Maple2.File.Ingest/Mapper/MapDataMapper.cs
@@ -141,6 +141,8 @@ public class MapDataMapper : TypeMapper<MapDataMetadata> {
                             Rotation: placeable.Rotation,
                             Scale: placeable.Scale,
                             Bounds: entityBounds,
+                            BreakDefense: vibrate.brokenDefence,
+                            BreakTick: vibrate.brokenTick,
                             VibrateIndex: vibrateObjectId++);
 
                         break;

--- a/Maple2.Model/Enum/Skill.cs
+++ b/Maple2.Model/Enum/Skill.cs
@@ -95,7 +95,7 @@ public enum ApplyTargetType {
     Friendly = 2,
     Player1 = 3, // Unknown,
     Player2 = 5, // Unknown,
-    Player3 = 6, // Unknown, Recovery
+    RegionBuff = 6,
     Player4 = 7, // Unknown, Debuff (Archeon's ice bombs)
     HungryMobs = 8
 }

--- a/Maple2.Model/Game/Field/FieldAccelerationStructure.cs
+++ b/Maple2.Model/Game/Field/FieldAccelerationStructure.cs
@@ -273,6 +273,10 @@ public class FieldAccelerationStructure : IByteSerializable, IByteDeserializable
 
         return vibrateObjects;
     }
+
+    public FieldVibrateEntity? GetVibrateEntity(string entityId) {
+        return vibrateEntities.FirstOrDefault(vibrateEntity => vibrateEntity.Id.Id == entityId);
+    }
     #endregion
 
     #region Initialization
@@ -570,6 +574,8 @@ public class FieldAccelerationStructure : IByteSerializable, IByteDeserializable
                 Rotation: new Vector3(0, 0, 0),
                 Scale: 1,
                 Bounds: new BoundingBox3(),
+                BreakDefense: 0,
+                BreakTick: 0,
                 VibrateIndex: i));
         }
 
@@ -759,6 +765,8 @@ public class FieldAccelerationStructure : IByteSerializable, IByteDeserializable
         switch (entity) {
             case FieldVibrateEntity vibrateEntity:
                 writer.Write(vibrateEntity.VibrateIndex);
+                writer.WriteInt(vibrateEntity.BreakDefense);
+                writer.WriteInt(vibrateEntity.BreakTick);
                 break;
             case FieldSpawnTile spawnTile:
                 break;
@@ -811,6 +819,8 @@ public class FieldAccelerationStructure : IByteSerializable, IByteDeserializable
                 Rotation: new Vector3(0, 0, 0),
                 Scale: 1,
                 Bounds: new BoundingBox3(),
+                BreakDefense: 0,
+                BreakTick: 0,
                 VibrateIndex: i));
         }
 
@@ -904,7 +914,9 @@ public class FieldAccelerationStructure : IByteSerializable, IByteDeserializable
                     Rotation: rotation,
                     Scale: scale,
                     Bounds: bounds,
-                    VibrateIndex: reader.ReadInt());
+                    VibrateIndex: reader.ReadInt(),
+                    BreakDefense: reader.ReadInt(),
+                    BreakTick: reader.ReadInt());
             case FieldEntityType.SpawnTile:
                 return new FieldSpawnTile(
                     Id: id,

--- a/Maple2.Model/Metadata/FieldEntity/FieldEntity.cs
+++ b/Maple2.Model/Metadata/FieldEntity/FieldEntity.cs
@@ -43,6 +43,8 @@ public record FieldVibrateEntity(
     Vector3 Rotation,
     float Scale,
     BoundingBox3 Bounds,
+    int BreakDefense,
+    int BreakTick,
     int VibrateIndex) : FieldEntity(Id, Position, Rotation, Scale, Bounds);
 
 public record FieldSpawnTile(

--- a/Maple2.Server.Game/Manager/Config/BuffManager.cs
+++ b/Maple2.Server.Game/Manager/Config/BuffManager.cs
@@ -353,6 +353,10 @@ public class BuffManager : IUpdatable {
         }
         foreach (AdditionalEffectMetadataModifyOverlapCount modifyOverlapCount in buff.Metadata.ModifyOverlapCount) {
             foreach (Buff buffResult in EnumerateBuffs(modifyOverlapCount.Id).Where(b => b.Stack(modifyOverlapCount.OffsetCount))) {
+                if (buffResult.Stacks <= 0) {
+                    Remove(buffResult.Id, buffResult.Caster.ObjectId);
+                    continue;
+                }
                 Actor.Field.Broadcast(BuffPacket.Update(buffResult));
             }
         }

--- a/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.Factory.cs
+++ b/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.Factory.cs
@@ -349,16 +349,13 @@ public partial class FieldManager {
 
         private FieldManager? GetInternal(int mapId, long ownerId = 0, int roomId = 0) {
             if (roomId != 0) { // Specified room
-                FieldManager? foundField = FindRoom(mapId, roomId);
+                FieldManager? foundField = FindRoom();
                 if (foundField != null) {
                     return foundField;
                 }
             }
 
             if (ServerTableMetadata.InstanceFieldTable.Entries.TryGetValue(mapId, out InstanceFieldMetadata? metadata)) {
-                if (ownerId == 0 && roomId == 0) {
-                    return Create(mapId);
-                }
                 switch (metadata.Type) {
                     case InstanceType.ugcMap: // this is both homes and UGD. Currently just doing homes.
                         if (roomId != 0) { // User wants to go into decorplanner or blueprint designer
@@ -370,6 +367,16 @@ public partial class FieldManager {
                         return homeField;
                     case InstanceType.DungeonLobby:
                         return Create(mapId, ownerId: ownerId, roomId: roomId); // TODO: this should never happen.
+                    case InstanceType.channelScale:
+                        if (fields.TryGetValue(mapId, out ConcurrentDictionary<int, FieldManager>? scalingFields) && !scalingFields.IsEmpty) {
+                            return scalingFields.Values.FirstOrDefault();
+                        }
+                        break;
+                    default:
+                        if (ownerId == 0 && roomId == 0) {
+                            return Create(mapId);
+                        }
+                        break;
                 }
             }
 
@@ -377,7 +384,7 @@ public partial class FieldManager {
                 return Create(mapId, ownerId: ownerId, roomId: roomId);
             }
 
-            if (roomId == 0 && mapFields.Count > 0) {
+            if (roomId == 0 && !mapFields.IsEmpty) {
                 FieldManager? firstField = mapFields.Values.FirstOrDefault();
                 if (firstField != null) {
                     return firstField;
@@ -387,7 +394,7 @@ public partial class FieldManager {
             return mapFields.TryGetValue(roomId, out FieldManager? field) ? field :
                 Create(mapId, ownerId: ownerId, roomId: roomId);
 
-            FieldManager? FindRoom(int mapId, int roomId) {
+            FieldManager? FindRoom() {
                 if (fields.TryGetValue(mapId, out ConcurrentDictionary<int, FieldManager>? roomFields) && roomFields.TryGetValue(roomId, out FieldManager? field)) {
                     return field;
                 }

--- a/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.Factory.cs
+++ b/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.Factory.cs
@@ -369,7 +369,7 @@ public partial class FieldManager {
                         return Create(mapId, ownerId: ownerId, roomId: roomId); // TODO: this should never happen.
                     case InstanceType.channelScale:
                         if (fields.TryGetValue(mapId, out ConcurrentDictionary<int, FieldManager>? scalingFields) && !scalingFields.IsEmpty) {
-                            return scalingFields.Values.FirstOrDefault();
+                            return scalingFields.Values.FirstOrDefault(f => !f.Disposed);
                         }
                         break;
                     default:

--- a/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.State.cs
+++ b/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.State.cs
@@ -495,6 +495,8 @@ public partial class FieldManager {
                 return [];
             case ApplyTargetType.HungryMobs:
                 return prisms.Filter(Pets.Values.Where(pet => pet.OwnerId == 0), limit, ignore);
+            case ApplyTargetType.RegionBuff:
+                return prisms.Filter(Players.Values, limit, ignore);
             default:
                 Log.Debug("Unhandled SkillEntity:{Entity}", targetType);
                 return [];

--- a/Maple2.Server.Game/Model/Field/Actor/FieldActor.cs
+++ b/Maple2.Server.Game/Model/Field/Actor/FieldActor.cs
@@ -5,6 +5,7 @@ using Maple2.Server.Game.Manager.Field;
 using Maple2.Tools.VectorMath;
 using Maple2.Tools.Collision;
 using Maple2.Database.Storage;
+using Maple2.Model.Metadata;
 using Maple2.Server.Game.Manager;
 using Maple2.Server.Game.Model.ActorStateComponent;
 using Maple2.Server.Game.Model.Skill;
@@ -12,13 +13,12 @@ using Maple2.Server.Game.Model.Skill;
 namespace Maple2.Server.Game.Model;
 
 // Dummy Actor for field to own entities.
-internal sealed class FieldActor : IActor {
+public class FieldActor : Actor<MapMetadata> {
     public FieldManager Field { get; }
     public NpcMetadataStorage NpcMetadata { get; init; }
 
-    public int ObjectId => 0;
     public bool IsDead => false;
-    public IPrism Shape => new PointPrism(Position);
+    public override IPrism Shape => new PointPrism(Position);
     public ActorState State => ActorState.None;
     public ActorSubState SubState => ActorSubState.None;
     public Vector3 Position { get => Transform.Position; set => Transform.Position = value; }
@@ -30,7 +30,7 @@ internal sealed class FieldActor : IActor {
     public SkillState SkillState { get; init; }
     public SkillQueue ActiveSkills { get; init; }
 
-    public FieldActor(FieldManager field, NpcMetadataStorage npcMetadata) {
+    public FieldActor(FieldManager field, int objectId, MapMetadata mapMetadata, NpcMetadataStorage npcMetadata) : base(field, objectId, mapMetadata, npcMetadata) {
         Field = field;
         Stats = new StatsManager(this);
         Buffs = new BuffManager(this);

--- a/Maple2.Server.Game/Model/Field/Entity/FieldSkill.cs
+++ b/Maple2.Server.Game/Model/Field/Entity/FieldSkill.cs
@@ -173,8 +173,7 @@ public class FieldSkill : FieldEntity<SkillMetadata> {
                     //     }
                     // }
 
-                    Field.VibrateObjects(record, Position);
-
+                    Field.VibrateObjects(damage, Position);
                     foreach (IActor target in targets) {
                         target.ApplyDamage(Caster, damage, attack);
                         // TODO: Set PrevUid?
@@ -188,6 +187,7 @@ public class FieldSkill : FieldEntity<SkillMetadata> {
                         Field.Broadcast(SkillDamagePacket.Target(record, targetRecords));
                         Field.Broadcast(SkillDamagePacket.Region(damage));
                     }
+
                     Caster.ApplyEffects(attack.SkillsOnDamage, Caster, damage, targets: targets);
                     Caster.ApplyEffects(attack.Skills, Caster, Caster, skillId: Value.Id, targets: targets);
                 }

--- a/Maple2.Server.Game/PacketHandlers/RequestCubeHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/RequestCubeHandler.cs
@@ -303,6 +303,7 @@ public class RequestCubeHandler : PacketHandler<GameSession> {
 
         session.HeldLiftup = weapon;
         session.Field.Broadcast(CubePacket.LiftupObject(session.Player, session.HeldLiftup));
+        session.Player.InBattle = true;
     }
 
     private void HandleLiftupDrop(GameSession session) {

--- a/Maple2.Server.Game/Packets/VibratePacket.cs
+++ b/Maple2.Server.Game/Packets/VibratePacket.cs
@@ -12,16 +12,16 @@ public static class VibratePacket {
         Invoke = 2,
     }
 
-    public static ByteWriter Attack(string entityId, SkillRecord skill) {
+    public static ByteWriter Attack(string entityId, DamageRecord damage) {
         var pWriter = Packet.Of(SendOp.Vibrate);
         pWriter.Write<Command>(Command.Attack);
         pWriter.WriteString(entityId);
-        pWriter.WriteLong(skill.CastUid);
-        pWriter.WriteInt(skill.SkillId);
-        pWriter.WriteShort(skill.Level);
-        pWriter.WriteByte(skill.MotionPoint);
-        pWriter.WriteByte(skill.AttackPoint);
-        pWriter.Write<Vector3S>(skill.Position);
+        pWriter.WriteLong(damage.SkillUid);
+        pWriter.WriteInt(damage.SkillId);
+        pWriter.WriteShort(damage.Level);
+        pWriter.WriteByte(damage.MotionPoint);
+        pWriter.WriteByte(damage.AttackPoint);
+        pWriter.Write<Vector3S>(damage.Position);
         pWriter.WriteInt(Environment.TickCount);
         pWriter.WriteString();
         pWriter.WriteByte();


### PR DESCRIPTION
- If Instance map is `channelScale` type, allow for others to also join first available field (This allows for event maps not to be solo instances)
- Adjust Vibrate cubes to only vibrate from region skills if they have BrokenOffense > 0
- Fixed healing spots not applying buffs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for new vibration entity properties, including BreakDefense and BreakTick, which are now tracked and persisted.
  - Introduced a method to retrieve vibration entities by their ID.

- **Improvements**
  - Enhanced field selection and creation logic to better handle new instance types and concurrency.
  - Updated skill targeting to support a new RegionBuff type.
  - Improved vibration and breakage handling during skill and damage interactions.

- **Bug Fixes**
  - Corrected player state when lifting objects to ensure battle status is set appropriately.

- **Refactor**
  - Renamed an enum member for clarity.
  - Refactored FieldActor to inherit from a base actor class and updated its constructor.
  - Streamlined skill and damage handling for vibration effects and network packets.

- **Chores**
  - Removed unused variables and cleaned up code for maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->