### PR TITLE
Misc additions

### DIFF
--- a/Maple2.File.Ingest/Mapper/ItemMapper.cs
+++ b/Maple2.File.Ingest/Mapper/ItemMapper.cs
@@ -111,7 +111,8 @@ public class ItemMapper : TypeMapper<ItemMetadata> {
             ItemMetadataFunction? function = string.IsNullOrWhiteSpace(data.function.name) ? null : new ItemMetadataFunction(
                 Type: Enum.Parse<ItemFunction>(data.function.name),
                 Name: data.function.name, // Temp duplicate data makes it easier to read DB
-                Parameters: data.function.parameter);
+                Parameters: data.function.parameter,
+                OnlyShadowWorld: data.function.onlyShadowContinent == 1);
 
             bool hasOption = data.option.@static > 0 || data.option.constant > 0 || data.option.random > 0 || data.option.optionID > 0;
             int levelFactor = (int) data.option.optionLevelFactor;

--- a/Maple2.Model/Enum/Skill.cs
+++ b/Maple2.Model/Enum/Skill.cs
@@ -94,8 +94,8 @@ public enum ApplyTargetType {
     Hostile = 1,
     Friendly = 2,
     Player1 = 3, // Unknown,
-    Player2 = 5, // Unknown,
-    RegionBuff = 6,
+    RegionBuff = 5, // Includes speed pads in Crazy Runners
+    RegionBuff2 = 6, // Includes Healing spots
     Player4 = 7, // Unknown, Debuff (Archeon's ice bombs)
     HungryMobs = 8
 }

--- a/Maple2.Model/Metadata/ItemMetadata.cs
+++ b/Maple2.Model/Metadata/ItemMetadata.cs
@@ -81,7 +81,8 @@ public record ItemMetadataSkill(
 public record ItemMetadataFunction(
     ItemFunction Type,
     string Name,
-    string Parameters);
+    string Parameters,
+    bool OnlyShadowWorld);
 
 public record ItemMetadataAdditionalEffect(
     int Id,

--- a/Maple2.Server.Game/Commands/PlayerCommand.cs
+++ b/Maple2.Server.Game/Commands/PlayerCommand.cs
@@ -52,6 +52,7 @@ public class PlayerCommand : GameCommand {
                 session.Stats.Refresh();
 
                 session.ConditionUpdate(ConditionType.level, targetLong: level);
+                session.ConditionUpdate(ConditionType.level_up, codeLong: (int) session.Player.Value.Character.Job.Code(), targetLong: level);
 
                 session.PlayerInfo.SendUpdate(new PlayerUpdateRequest {
                     AccountId = session.AccountId,

--- a/Maple2.Server.Game/Manager/AchievementManager.cs
+++ b/Maple2.Server.Game/Manager/AchievementManager.cs
@@ -128,6 +128,9 @@ public sealed class AchievementManager {
             GiveReward(achievement);
 
             session.Send(AchievementPacket.Update(achievement));
+            session.ConditionUpdate(ConditionType.revise_achieve_multi_grade, codeLong: achievement.Id, targetLong: achievement.CurrentGrade);
+            session.ConditionUpdate(ConditionType.revise_achieve_single_grade, codeLong: achievement.Id, targetLong: achievement.CurrentGrade);
+            session.ConditionUpdate(ConditionType.hero_achieve, codeLong: achievement.Id, targetLong: achievement.CurrentGrade);
             if (!achievement.Metadata.Grades.TryGetValue(achievement.CurrentGrade, out grade)) {
                 break;
             }

--- a/Maple2.Server.Game/Manager/Field/FieldManager/IField.cs
+++ b/Maple2.Server.Game/Manager/Field/FieldManager/IField.cs
@@ -59,7 +59,7 @@ public interface IField : IDisposable {
     public long FieldTick { get; }
     public virtual void Init() { }
 
-    public void AddSkill(SkillMetadata metadata, int interval, in Vector3 position, in Vector3 rotation = default);
+    public void AddSkill(SkillMetadata metadata, int interval, in Vector3 position, in Vector3 rotation = default, int triggerId = 0);
     public void AddSkill(SkillRecord record);
     public void AddSkill(IActor caster, SkillEffectMetadata effect, Vector3[] points, in Vector3 rotation = default);
     public IEnumerable<IActor> GetTargets(IActor actor, Prism[] prisms, ApplyTargetType targetType, int limit, ICollection<IActor>? ignore = null);

--- a/Maple2.Server.Game/Manager/Items/EquipManager.cs
+++ b/Maple2.Server.Game/Manager/Items/EquipManager.cs
@@ -131,6 +131,9 @@ public class EquipManager {
             item.Slot = (short) slot;
             equips[slot] = item;
             session.Field?.Broadcast(EquipPacket.EquipItem(session.Player, item, 0));
+            if (item.Template != null) {
+                session.ConditionUpdate(ConditionType.change_ugc_equip);
+            }
             session.Stats.Refresh();
             return true;
         }

--- a/Maple2.Server.Game/Model/Field/Entity/FieldSkill.cs
+++ b/Maple2.Server.Game/Model/Field/Entity/FieldSkill.cs
@@ -16,6 +16,7 @@ public class FieldSkill : FieldEntity<SkillMetadata> {
     public int FireCount { get; private set; }
     public bool Enabled => FireCount < 0 || NextTick <= endTick || Field.FieldTick <= endTick;
     public bool Active { get; private set; } = true;
+    public int TriggerId { get; init; }
 
     public readonly Vector3[] Points;
     public readonly bool UseDirection;

--- a/Maple2.Server.Game/PacketHandlers/MailHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/MailHandler.cs
@@ -90,6 +90,7 @@ public class MailHandler : PacketHandler<GameSession> {
             return;
         }
 
+        session.ConditionUpdate(ConditionType.send_mail);
         session.Send(MailPacket.Send(mail.Id));
         try {
             session.World.MailNotification(new MailNotificationRequest {

--- a/Maple2.Server.Game/PacketHandlers/PlayerHostHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/PlayerHostHandler.cs
@@ -32,6 +32,14 @@ public class PlayerHostHandler : PacketHandler<GameSession> {
             return;
         }
 
-        hongBao.Claim(session.Player);
+        Item? item = hongBao.Claim(session.Player);
+        if (item == null) {
+            return;
+        }
+
+        session.Send(PlayerHostPacket.GiftHongBao(session.Player, hongBao, item.Amount));
+        if (!session.Item.Inventory.Add(item, true)) {
+            session.Item.MailItem(item);
+        }
     }
 }

--- a/Maple2.Server.Game/PacketHandlers/SkillHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/SkillHandler.cs
@@ -255,6 +255,8 @@ public class SkillHandler : PacketHandler<GameSession> {
                         record.Targets.TryAdd(pet.ObjectId, pet);
                     }
                     continue;
+                case ApplyTargetType.RegionBuff:
+                case ApplyTargetType.RegionBuff2:
                 default:
                     Logger.Debug("Unhandled Target-SkillEntity:{Entity}", record.Attack.Range.ApplyTarget);
                     continue;

--- a/Maple2.Server.Game/PacketHandlers/TaxiHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/TaxiHandler.cs
@@ -88,6 +88,8 @@ public class TaxiHandler : PacketHandler<GameSession> {
         }
         session.Currency.Meso -= cost;
 
+        session.ConditionUpdate(ConditionType.taxiuse);
+        session.ConditionUpdate(ConditionType.taxifee, counter: cost);
         Vector3 position = entities.Taxi.Position.Offset(-VectorExtensions.BLOCK_SIZE, entities.Taxi.Rotation);
         Vector3 rotation = entities.Taxi.Rotation;
         session.Send(session.PrepareField(mapId, position: position, rotation: rotation)

--- a/Maple2.Server.Game/PacketHandlers/UserChatHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/UserChatHandler.cs
@@ -44,32 +44,34 @@ public class UserChatHandler : PacketHandler<GameSession> {
         switch (type) {
             case ChatType.Normal:
                 HandleNormal(session, message, itemUids);
-                return;
+                break;
             case ChatType.WhisperTo:
                 HandleWhisper(session, message, recipient, itemUids);
-                return;
+                break;
             case ChatType.Party:
                 HandleParty(session, message, itemUids);
-                return;
+                break;
             case ChatType.Guild:
                 HandleGuild(session, message, itemUids);
-                return;
+                break;
             case ChatType.World:
                 HandleWorld(session, message, itemUids);
-                return;
+                break;
             case ChatType.Channel:
                 HandleChannel(session, message, itemUids);
-                return;
+                break;
             case ChatType.Super:
                 HandleSuper(session, message, itemUids);
-                return;
+                break;
             case ChatType.Club:
                 HandleClub(session, message, clubId, itemUids);
-                return;
+                break;
             case ChatType.Wedding:
                 HandleWedding(session, message, itemUids);
-                return;
+                break;
         }
+
+        session.ConditionUpdate(ConditionType.chat, targetLong: session.Field.MapId);
     }
 
     private static void HandleNormal(GameSession session, string message, ICollection<long> itemUids) {

--- a/Maple2.Server.Game/Packets/ItemUsePacket.cs
+++ b/Maple2.Server.Game/Packets/ItemUsePacket.cs
@@ -13,6 +13,24 @@ public static class ItemUsePacket {
         BeautyCoupon = 6,
     }
 
+    // s_msg_expand_inven_complete
+    // - Your inventory has been expanded.
+    public static ByteWriter ExpandInventory() {
+        var pWriter = Packet.Of(SendOp.ItemUse);
+        pWriter.Write<Command>(Command.ExpandInventory);
+
+        return pWriter;
+    }
+
+    // s_msg_expand_inven_already_maximum
+    // - You cannot expand your inventory any further.
+    public static ByteWriter MaxInventory() {
+        var pWriter = Packet.Of(SendOp.ItemUse);
+        pWriter.Write<Command>(Command.MaxInventory);
+
+        return pWriter;
+    }
+
     // s_msg_expand_character_slot_complete
     // - A character slot has been added.
     public static ByteWriter CharacterSlotAdded() {

--- a/Maple2.Server.Game/Packets/PlayerHostPacket.cs
+++ b/Maple2.Server.Game/Packets/PlayerHostPacket.cs
@@ -18,10 +18,15 @@ public static class PlayerHostPacket {
         AdBalloonWindow = 6,
     }
 
-    public static ByteWriter UseHongBao(HongBao hongBao) {
+    public static ByteWriter UseHongBao(HongBao hongBao, int amount) {
         var pWriter = Packet.Of(SendOp.PlayerHost);
         pWriter.Write<Command>(Command.UseHongBao);
-        pWriter.WriteClass<HongBao>(hongBao);
+        pWriter.WriteInt(hongBao.SourceItemId);
+        pWriter.WriteInt(hongBao.ObjectId);
+        pWriter.WriteInt(hongBao.ItemId);
+        pWriter.WriteInt(amount);
+        pWriter.WriteInt(hongBao.MaxUserCount - 1);
+        pWriter.WriteUnicodeString(hongBao.Owner.Value.Character.Name);
 
         return pWriter;
     }

--- a/Maple2.Server.Game/Trigger/TriggerContext.Field.cs
+++ b/Maple2.Server.Game/Trigger/TriggerContext.Field.cs
@@ -325,17 +325,21 @@ public partial class TriggerContext {
     public void SetSkill(int[] triggerIds, bool enabled) {
         DebugLog("[SetSkill] triggerIds:{Ids}, enabled:{Enabled}", string.Join(", ", triggerIds), enabled);
         foreach (int triggerId in triggerIds) {
-            Ms2TriggerSkill? skill = Field.Entities.Trigger.Skills.FirstOrDefault(x => x.TriggerId == triggerId);
-            if (skill == null) {
-                continue;
-            }
+            if (enabled) {
+                Ms2TriggerSkill? skill = Field.Entities.Trigger.Skills.FirstOrDefault(x => x.TriggerId == triggerId);
+                if (skill == null) {
+                    continue;
+                }
 
-            if (!Field.SkillMetadata.TryGet(skill.SkillId, skill.Level, out var skillMetadata)) {
-                logger.Warning("Invalid skill: {Id}", skill.SkillId);
-                continue;
-            }
+                if (!Field.SkillMetadata.TryGet(skill.SkillId, skill.Level, out SkillMetadata? skillMetadata)) {
+                    logger.Warning("Invalid skill: {Id}", skill.SkillId);
+                    continue;
+                }
 
-            Field.AddSkill(skillMetadata, 0, skill.Position, skill.Rotation);
+                Field.AddSkill(skillMetadata, (int) TimeSpan.FromMilliseconds(150).TotalMilliseconds, skill.Position, skill.Rotation, triggerId);
+            } else {
+                Field.RemoveSkillByTriggerId(triggerId);
+            }
         }
     }
 

--- a/Maple2.Server.Game/Util/ConditionUtil.cs
+++ b/Maple2.Server.Game/Util/ConditionUtil.cs
@@ -114,6 +114,9 @@ public static class ConditionUtil {
             case ConditionType.explore_continent:
             case ConditionType.continent:
             case ConditionType.explore:
+            case ConditionType.revise_achieve_multi_grade:
+            case ConditionType.revise_achieve_single_grade:
+            case ConditionType.hero_achieve_grade:
                 if (code.Range != null && InRange((ConditionMetadata.Range<int>) code.Range, (int) longValue)) {
                     return true;
                 }
@@ -163,6 +166,11 @@ public static class ConditionUtil {
             case ConditionType.home_doctor:
             case ConditionType.resolve_panelty:
             case ConditionType.hit_tombstone:
+            case ConditionType.taxiuse:
+            case ConditionType.taxifee:
+            case ConditionType.chat:
+            case ConditionType.send_mail:
+            case ConditionType.change_ugc_equip:
                 return true;
         }
         return false;
@@ -221,6 +229,9 @@ public static class ConditionUtil {
             case ConditionType.music_play_instrument_time:
             case ConditionType.music_play_score:
             case ConditionType.music_play_ensemble_in:
+            case ConditionType.revise_achieve_multi_grade:
+            case ConditionType.revise_achieve_single_grade:
+            case ConditionType.chat:
                 if (target.Range != null && target.Range.Value.Min >= longValue &&
                     target.Range.Value.Max <= longValue) {
                     return true;
@@ -296,6 +307,11 @@ public static class ConditionUtil {
             case ConditionType.home_doctor:
             case ConditionType.resolve_panelty:
             case ConditionType.hit_tombstone:
+            case ConditionType.hero_achieve_grade:
+            case ConditionType.taxiuse:
+            case ConditionType.taxifee:
+            case ConditionType.send_mail:
+            case ConditionType.change_ugc_equip:
                 return true;
         }
         return false;


### PR DESCRIPTION
Adds a few more quest/achievement types

More adjustments on HongBao to correctly display the amount/player count on use

Implemented removing region skills via triggers

Implemented ApplyTargetType 5 - this handles some region buffs like certain crazy runner speed/slow pads

Added some additional ItemUse items

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for new skill trigger management, allowing skills to be added or removed based on trigger IDs.
	- Expanded region buff types for skills, including new healing spot buffs.
	- Introduced item functions for adding additional effects and expanding inventory.
- **Enhancements**
	- Improved achievement and condition tracking for various actions such as leveling up, equipping items, sending mail, using taxis, and chatting.
	- Enhanced item claiming and distribution logic for HongBao rewards, including inventory and mail fallback.
	- Added inventory expansion feedback with success and max capacity notifications.
- **Bug Fixes**
	- Unified condition updates to ensure consistent progress tracking across multiple player actions.
- **API Changes**
	- Updated method signatures and interfaces to support new skill trigger and HongBao handling features.
	- Modified inventory expansion method to return success status and accept variable expansion size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->