### PR TITLE
Feat: More Game Events

### DIFF
--- a/Maple2.Database/Model/GameEventUserValue.cs
+++ b/Maple2.Database/Model/GameEventUserValue.cs
@@ -24,9 +24,8 @@ internal class GameEventUserValue {
 
     [return: NotNullIfNotNull(nameof(other))]
     public static implicit operator Maple2.Model.Game.GameEventUserValue?(GameEventUserValue? other) {
-        return other == null ? null : new Maple2.Model.Game.GameEventUserValue {
+        return other == null ? null : new Maple2.Model.Game.GameEventUserValue(other.Value) {
             Type = other.Type,
-            Value = other.Value,
             EventId = other.EventId,
             ExpirationTime = other.ExpirationTime,
         };

--- a/Maple2.Model/Enum/GameEventUserValueType.cs
+++ b/Maple2.Model/Enum/GameEventUserValueType.cs
@@ -28,4 +28,9 @@ public enum GameEventUserValueType {
     // Rock Paper Scissors Event
     RPSDailyMatches = 1800,
     RPSRewardsClaimed = 1801,
+
+    // Bingo - TODO: These are not the actual confirmed values. Just using it as a way to store this data for now.
+    BingoUid = 4000,
+    BingoRewardsClaimed = 4001,
+    BingoNumbersChecked = 4002,
 }

--- a/Maple2.Model/Game/Event/GameEvent.cs
+++ b/Maple2.Model/Game/Event/GameEvent.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Linq;
-using Maple2.Model.Enum;
+﻿using Maple2.Model.Enum;
 using Maple2.Model.Metadata;
 using Maple2.PacketLib.Tools;
 using Maple2.Tools;
@@ -205,6 +203,38 @@ public class GameEvent : IByteSerializable {
                 writer.WriteInt(gallery.RevealDayLimit);
                 writer.WriteUnicodeString(gallery.Image);
                 writer.WriteLong(EndTime);
+                break;
+            case BingoEvent bingo:
+                writer.WriteInt(Id);
+                writer.WriteInt(bingo.Rewards.Length);
+                foreach (BingoEvent.BingoReward bingoReward in bingo.Rewards) {
+                    writer.WriteInt(bingoReward.Items.Length);
+                    foreach (RewardItem rewardItem in bingoReward.Items) {
+                        writer.Write<RewardItem>(rewardItem);
+                    }
+                }
+                writer.WriteInt(bingo.PencilItemId);
+                writer.WriteInt(bingo.PencilPlusItemId);
+                break;
+            case TimeRunEvent timeRun:
+                writer.WriteInt(Id);
+                writer.WriteInt(timeRun.StartItemId); // Guess
+
+                writer.WriteInt(timeRun.Quests.Sum(q => q.Distance));
+                writer.WriteInt(timeRun.Quests.Length);
+                foreach (TimeRunEvent.Quest quest in timeRun.Quests) {
+                    writer.WriteInt(quest.Id);
+                    writer.WriteInt(quest.Distance);
+                    writer.WriteShort((short) quest.OpeningDay);
+                }
+
+                writer.Write<RewardItem>(timeRun.FinalReward);
+                writer.WriteInt(timeRun.StepRewards.Count);
+                foreach ((int steps, RewardItem rewardItem) in timeRun.StepRewards) {
+                    writer.WriteInt(steps);
+                    writer.Write<RewardItem>(rewardItem);
+                }
+
                 break;
         }
     }

--- a/Maple2.Model/Game/User/GameEventUserValue.cs
+++ b/Maple2.Model/Game/User/GameEventUserValue.cs
@@ -6,12 +6,12 @@ namespace Maple2.Model.Game;
 
 public class GameEventUserValue : IByteSerializable {
     public GameEventUserValueType Type { get; init; }
-    public string Value;
+    public string Value { get; private set; }
     public int EventId { get; init; }
     public long ExpirationTime { get; init; }
 
-    public GameEventUserValue() {
-        Value = string.Empty;
+    public GameEventUserValue(string value = "") {
+        Value = value;
     }
 
     public GameEventUserValue(GameEventUserValueType type, long expirationTime, int eventId) {
@@ -19,6 +19,10 @@ public class GameEventUserValue : IByteSerializable {
         Type = type;
         ExpirationTime = expirationTime;
         EventId = eventId;
+    }
+
+    public void SetValue(string value) {
+        Value = value;
     }
 
     public int Int() => int.TryParse(Value, out int result) ? result : 0;

--- a/Maple2.Model/Metadata/ServerTable/GameEventTable.cs
+++ b/Maple2.Model/Metadata/ServerTable/GameEventTable.cs
@@ -162,6 +162,59 @@ public record Gallery(
     int RevealDayLimit,
     string Image) : GameEventData;
 
+/// <summary>
+/// Bingo Event
+/// </summary>
+/// <param name="PencilItemId">Normal pencil item ID used for standard crossing out daily bingo numbers</param>
+/// <param name="PencilPlusItemId">Plus pencil item ID used for crossing out any number</param>
+/// <param name="Numbers">The bingo numbers selected per day. MUST have enough days for the amount of days the event will run for.</param>
+/// <param name="Rewards">The rewards for the amount of bingos you get.</param>
+public record BingoEvent(
+    int PencilItemId,
+    int PencilPlusItemId,
+    int[][] Numbers,
+    BingoEvent.BingoReward[] Rewards
+) : GameEventData {
+
+    public record BingoReward(
+        RewardItem[] Items);
+}
+
+/// <summary>
+/// Race Against Time Event
+/// </summary>
+/// <param name="StartItemId">Item needed to start the event.</param>
+/// <param name="Quests">All the quests from using the StartItemId. Determines the distance user will travel and the day the quest is available. The timer on the event UI is determined by the start time of the quests.</param>
+/// <param name="StepRewards">Rewards claimable for reaching a certain distance.</param>
+/// <param name="FinalReward">Final reward</param>
+public record TimeRunEvent(
+    int StartItemId,
+    TimeRunEvent.Quest[] Quests,
+    IReadOnlyDictionary<int, RewardItem> StepRewards,
+    RewardItem FinalReward) : GameEventData {
+    public record Quest(
+        int Id,
+        int Distance,
+        int OpeningDay);
+}
+
+
+/// <summary>
+/// Enables Maple Survival (Mushking Royale). Possibly does not work.
+/// </summary>
+public record MapleSurvivalOpenPeriod : GameEventData;
+
+
+/// <summary>
+/// Closes Maple Survival (Mushking Royale)
+/// </summary>
+public record ShutdownMapleSurvival : GameEventData;
+
+/// <summary>
+/// Creates a popup for a On Time event. Clicking Participate triggers the user to send /AddOntimeEvent
+/// </summary>
+public record Ontime : GameEventData;
+
 public record LoginNotice : GameEventData;
 
 [JsonPolymorphic(TypeDiscriminatorPropertyName = "!")]
@@ -185,4 +238,9 @@ public record LoginNotice : GameEventData;
 [JsonDerivedType(typeof(UGCMapContractSale), "UGCMapContractSale")]
 [JsonDerivedType(typeof(UGCMapExtensionSale), "UGCMapExtensionSale")]
 [JsonDerivedType(typeof(Gallery), "Gallery")]
+[JsonDerivedType(typeof(BingoEvent), "BingoEvent")]
+[JsonDerivedType(typeof(TimeRunEvent), "TimeRunEvent")]
+[JsonDerivedType(typeof(MapleSurvivalOpenPeriod), "MapleSurvivalOpenPeriod")]
+[JsonDerivedType(typeof(ShutdownMapleSurvival), "ShutdownMapleSurvival")]
+[JsonDerivedType(typeof(Ontime), "Ontime")]
 public abstract record GameEventData;

--- a/Maple2.Server.Game/Manager/GameEventManager.cs
+++ b/Maple2.Server.Game/Manager/GameEventManager.cs
@@ -130,7 +130,8 @@ public sealed class GameEventManager {
             throw new ArgumentOutOfRangeException(nameof(type), type, "Invalid game event type.");
         }
 
-        gameEventUserValue.Value = value.ToString() ?? throw new ArgumentException("Invalid new value");
+        string newValue = value.ToString() ?? throw new ArgumentException("Invalid value type.");
+        gameEventUserValue.SetValue(newValue);
         session.Send(GameEventUserValuePacket.Update(gameEventUserValue));
     }
 
@@ -162,7 +163,7 @@ public sealed class GameEventManager {
         IEnumerable<GameEventUserValue> accumulatedTimeValues =
             eventValues.Values.SelectMany(dict => dict.Values.Where(value => value.Type == GameEventUserValueType.AttendanceAccumulatedTime));
         foreach (GameEventUserValue userValue in accumulatedTimeValues) {
-            userValue.Value = (DateTime.Now.AddSeconds(userValue.Long()) - session.Player.Value.Character.LastModified).Seconds.ToString();
+            userValue.SetValue((DateTime.Now.AddSeconds(userValue.Long()) - session.Player.Value.Character.LastModified).Seconds.ToString());
         }
         db.SaveGameEventUserValues(session.CharacterId, eventValues.Values.SelectMany(value => value.Values).ToList());
     }

--- a/Maple2.Server.Game/Manager/NpcScriptManager.cs
+++ b/Maple2.Server.Game/Manager/NpcScriptManager.cs
@@ -366,19 +366,21 @@ public sealed class NpcScriptManager {
             return;
         }
 
+        // NpcTalk packets have to be sent first before any movement, items, etc
+        if (scriptFunction.PortalId > 0) {
+            session.Send(NpcTalkPacket.MovePlayer(scriptFunction.PortalId));
+        }
+
         if (!string.IsNullOrEmpty(scriptFunction.UiName)) {
             session.Send(NpcTalkPacket.OpenDialog(scriptFunction.UiName, scriptFunction.UiArg));
         }
 
-        if (scriptFunction.PortalId > 0) {
-            if (session.Field.TryGetPortal(scriptFunction.PortalId, out FieldPortal? dstPortal)) {
-                session.Send(PortalPacket.MoveByPortal(session.Player, dstPortal));
-            }
-            session.Send(NpcTalkPacket.MovePlayer(scriptFunction.PortalId));
-        }
-
         if (!string.IsNullOrEmpty(scriptFunction.MoveMapMovie)) {
             session.Send(NpcTalkPacket.Cutscene(scriptFunction.MoveMapMovie));
+        }
+
+        if (scriptFunction.PortalId > 0 && session.Field.TryGetPortal(scriptFunction.PortalId, out FieldPortal? dstPortal)) {
+            session.Send(PortalPacket.MoveByPortal(session.Player, dstPortal));
         }
 
         if (scriptFunction.CollectItems.Count > 0) {

--- a/Maple2.Server.Game/PacketHandlers/EventRewardHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/EventRewardHandler.cs
@@ -179,7 +179,7 @@ public class EventRewardHandler : PacketHandler<GameSession> {
 
         DateTime startTime = gameEvent.StartTime.FromEpochSeconds();
         // days since event started
-        int days = Math.Max(0, (int)(DateTime.UtcNow - startTime).TotalDays);
+        int days = Math.Max(0, (int) (DateTime.UtcNow - startTime).TotalDays);
         if (days >= bingoEvent.Numbers.Length) {
             Logger.Error("Bingo event is incorrectly set up. There are not enough days for the event.");
             return;
@@ -219,7 +219,7 @@ public class EventRewardHandler : PacketHandler<GameSession> {
 
         if (itemId == bingoEvent.PencilItemId) {
             DateTime startTime = gameEvent.StartTime.FromEpochSeconds();
-            int days = Math.Max(0, (int)(DateTime.UtcNow - startTime).TotalDays);
+            int days = Math.Max(0, (int) (DateTime.UtcNow - startTime).TotalDays);
             if (!bingoEvent.Numbers[days].Contains(bingoNumber)) {
                 return;
             }

--- a/Maple2.Server.Game/PacketHandlers/EventRewardHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/EventRewardHandler.cs
@@ -188,7 +188,7 @@ public class EventRewardHandler : PacketHandler<GameSession> {
         // This uid sets up what board layout the user will have.
         GameEventUserValue uid = session.GameEvent.Get(GameEventUserValueType.BingoUid, gameEvent.Id, gameEvent.EndTime);
         if (string.IsNullOrEmpty(uid.Value)) {
-            session.GameEvent.Set(gameEvent.Id, GameEventUserValueType.BingoUid, uid.Value);
+            session.GameEvent.Set(gameEvent.Id, GameEventUserValueType.BingoUid, Random.Shared.Next().ToString());
         }
 
         GameEventUserValue checkedNumbers = session.GameEvent.Get(GameEventUserValueType.BingoNumbersChecked, gameEvent.Id, gameEvent.EndTime);

--- a/Maple2.Server.Game/PacketHandlers/ItemUseHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/ItemUseHandler.cs
@@ -120,6 +120,9 @@ public class ItemUseHandler : PacketHandler<GameSession> {
             case ItemFunction.ExpandInven:
                 HandleExpandInventory(session, item);
                 break;
+            case ItemFunction.QuestScroll:
+                HandleQuestScroll(session, item);
+                break;
             default:
                 Logger.Warning("Unhandled item function: {Name}", item.Metadata.Function?.Type);
                 return;
@@ -615,5 +618,20 @@ public class ItemUseHandler : PacketHandler<GameSession> {
 
         session.Send(ItemUsePacket.ExpandInventory());
         session.Item.Inventory.Consume(item.Uid, 1);
+    }
+
+    private void HandleQuestScroll(GameSession session, Item item) {
+        Dictionary<string, string> xmlParameters = XmlParseUtil.GetParameters(item.Metadata.Function?.Parameters);
+        if (!xmlParameters.ContainsKey("questID")) {
+            return;
+        }
+
+        int[] questIds = xmlParameters["questID"].Split(',').Select(int.Parse).ToArray();
+        foreach (int questId in questIds) {
+            session.Quest.Start(questId);
+        }
+
+        session.Item.Inventory.Consume(item.Uid, 1);
+        session.Send(ItemUsePacket.QuestScroll(item.Id));
     }
 }

--- a/Maple2.Server.Game/Packets/EventRewardPacket.cs
+++ b/Maple2.Server.Game/Packets/EventRewardPacket.cs
@@ -7,8 +7,44 @@ namespace Maple2.Server.Game.Packets;
 
 public static class EventRewardPacket {
     private enum Command : byte {
+        Unknown1 = 1,
+        ClaimTimeRunFinalReward = 3,
+        ClaimTimeRunStepReward = 4,
         FlipGalleryCard = 7,
         ClaimGalleryReward = 9,
+        OpenBingo = 20,
+        UpdateBingo = 21,
+        ClaimBingoReward = 23,
+    }
+
+    public static ByteWriter Unknown1(List<RewardItem> items) {
+        var pWriter = Packet.Of(SendOp.EventReward);
+        pWriter.Write<Command>(Command.Unknown1);
+        pWriter.WriteInt(items.Count);
+        foreach (RewardItem item in items) {
+            pWriter.WriteInt(item.ItemId);
+            pWriter.WriteShort(item.Rarity);
+        }
+
+        return pWriter;
+    }
+
+    public static ByteWriter ClaimTimeRunFinalReward(RewardItem rewardItem) {
+        var pWriter = Packet.Of(SendOp.EventReward);
+        pWriter.Write<Command>(Command.ClaimTimeRunFinalReward);
+        pWriter.WriteInt(rewardItem.ItemId);
+        pWriter.WriteShort(rewardItem.Rarity);
+
+        return pWriter;
+    }
+
+    public static ByteWriter ClaimTimeRunStepReward(RewardItem rewardItem) {
+        var pWriter = Packet.Of(SendOp.EventReward);
+        pWriter.Write<Command>(Command.ClaimTimeRunStepReward);
+        pWriter.WriteInt(rewardItem.ItemId);
+        pWriter.WriteShort(rewardItem.Rarity);
+
+        return pWriter;
     }
 
     public static ByteWriter FlipGalleryCard(byte index) {
@@ -26,6 +62,41 @@ public static class EventRewardPacket {
         foreach (RewardItem rewardItem in rewardItems) {
             pWriter.WriteInt(rewardItem.ItemId);
             pWriter.WriteShort(rewardItem.Rarity);
+        }
+
+        return pWriter;
+    }
+
+    public static ByteWriter OpenBingo(int uid, string checkedNumbers, string rewardsClaimed, int[] bingoNumbers) {
+        var pWriter = Packet.Of(SendOp.EventReward);
+        pWriter.Write<Command>(Command.OpenBingo);
+        pWriter.WriteInt(uid);
+        pWriter.WriteUnicodeString(checkedNumbers);
+        pWriter.WriteUnicodeString(rewardsClaimed);
+        pWriter.WriteInt(bingoNumbers.Length);
+        foreach (int number in bingoNumbers) {
+            pWriter.WriteInt(number);
+        }
+
+        return pWriter;
+    }
+
+    public static ByteWriter UpdateBingo(string checkedNumbers, string rewardsClaimed) {
+        var pWriter = Packet.Of(SendOp.EventReward);
+        pWriter.Write<Command>(Command.UpdateBingo);
+        pWriter.WriteUnicodeString(checkedNumbers);
+        pWriter.WriteUnicodeString(rewardsClaimed);
+
+        return pWriter;
+    }
+
+    public static ByteWriter ClaimBingoReward(RewardItem[] rewards) {
+        var pWriter = Packet.Of(SendOp.EventReward);
+        pWriter.Write<Command>(Command.ClaimBingoReward);
+        pWriter.WriteInt(rewards.Length);
+        foreach (RewardItem reward in rewards) {
+            pWriter.WriteInt(reward.ItemId);
+            pWriter.WriteShort(reward.Rarity);
         }
 
         return pWriter;

--- a/Maple2.Server.Game/Packets/GameEventUserValuePacket.cs
+++ b/Maple2.Server.Game/Packets/GameEventUserValuePacket.cs
@@ -1,4 +1,5 @@
-﻿using Maple2.Model.Game;
+﻿using Maple2.Database.Extensions;
+using Maple2.Model.Game;
 using Maple2.PacketLib.Tools;
 using Maple2.Server.Core.Constants;
 using Maple2.Server.Core.Packets;
@@ -29,6 +30,20 @@ public static class GameEventUserValuePacket {
         pWriter.Write<Command>(Command.Update);
         pWriter.WriteByte();
         pWriter.WriteClass<GameEventUserValue>(userValue);
+
+        return pWriter;
+    }
+
+    public static ByteWriter Test(int i) {
+        var pWriter = Packet.Of(SendOp.GameEventUserValue);
+        pWriter.Write<Command>(Command.Update);
+        pWriter.WriteByte();
+
+        //pWriter.WriteInt(1);
+        pWriter.WriteInt(i);
+        pWriter.WriteInt(700001);
+        pWriter.WriteUnicodeString("False");
+        pWriter.WriteLong(DateTime.Now.AddYears(1).ToEpochSeconds());
 
         return pWriter;
     }

--- a/Maple2.Server.Game/Packets/GameEventUserValuePacket.cs
+++ b/Maple2.Server.Game/Packets/GameEventUserValuePacket.cs
@@ -33,18 +33,4 @@ public static class GameEventUserValuePacket {
 
         return pWriter;
     }
-
-    public static ByteWriter Test(int i) {
-        var pWriter = Packet.Of(SendOp.GameEventUserValue);
-        pWriter.Write<Command>(Command.Update);
-        pWriter.WriteByte();
-
-        //pWriter.WriteInt(1);
-        pWriter.WriteInt(i);
-        pWriter.WriteInt(700001);
-        pWriter.WriteUnicodeString("False");
-        pWriter.WriteLong(DateTime.Now.AddYears(1).ToEpochSeconds());
-
-        return pWriter;
-    }
 }

--- a/Maple2.Server.Game/Packets/ItemUsePacket.cs
+++ b/Maple2.Server.Game/Packets/ItemUsePacket.cs
@@ -10,6 +10,7 @@ public static class ItemUsePacket {
         MaxInventory = 1,
         CharacterSlotAdded = 2,
         MaxCharacterSlots = 3,
+        QuestScroll = 4,
         BeautyCoupon = 6,
     }
 
@@ -46,6 +47,13 @@ public static class ItemUsePacket {
         var pWriter = Packet.Of(SendOp.ItemUse);
         pWriter.Write<Command>(Command.MaxCharacterSlots);
 
+        return pWriter;
+    }
+
+    public static ByteWriter QuestScroll(int itemId) {
+        var pWriter = Packet.Of(SendOp.ItemUse);
+        pWriter.Write<Command>(Command.QuestScroll);
+        pWriter.WriteInt(itemId);
         return pWriter;
     }
 


### PR DESCRIPTION
- Implements Bingo event
- Partial implementation of TimeRunEvent
- Fixed Mirror NPC in Beauty Salon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced support for new in-game events: Bingo and TimeRun, including event data handling, serialization, and reward claiming.
  - Added new event types for Maple Survival (opening/closure) and On Time popups.
  - Implemented Bingo board interactions: opening the board, crossing off numbers, and claiming rewards.
  - Added support for using Quest Scroll items to start quests directly from inventory.

- **Enhancements**
  - Improved event reward handling with new commands for TimeRun and Bingo events.
  - Updated NPC script interactions to ensure dialog and movement packets are sent in the correct order.
  - Refined user value management with controlled value setting methods.

- **Other Changes**
  - Extended enums and data models to support new event types and user values.
  - Added new packet commands and constructions for event rewards and item use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->