### PR TITLE
Fix DateTime parsing on season data tables

### DIFF
--- a/Maple2.File.Ingest/Mapper/TableMapper.cs
+++ b/Maple2.File.Ingest/Mapper/TableMapper.cs
@@ -1756,8 +1756,8 @@ public class TableMapper : TypeMapper<TableMetadata> {
             foreach ((int id, SeasonData seasonData) in seasonDataParser) {
                 results.Add(id, new SeasonDataTable.Entry(
                     Id: seasonData.seasonID,
-                    StartTime: DateTime.ParseExact(seasonData.eventStart, "yyyy-MM-dd-HH-mm-ss", CultureInfo.InvariantCulture),
-                    EndTime: DateTime.ParseExact(seasonData.eventEnd, "yyyy-MM-dd-HH-mm-ss", CultureInfo.InvariantCulture),
+                    StartTime: DateTime.TryParseExact(seasonData.eventStart, "yyyy-MM-dd-HH-mm-ss", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime startTime) ? startTime : DateTime.MinValue,
+                    EndTime: DateTime.TryParseExact(seasonData.eventEnd, "yyyy-MM-dd-HH-mm-ss", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime endTime) ? endTime : DateTime.MaxValue,
                     Grades: [
                         seasonData.grade1,
                         seasonData.grade2,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of invalid season start and end dates to prevent errors and ensure default values are used when date formats are incorrect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->