### PR TITLE
Fall back to cmd if windows terminal isn't installed

### DIFF
--- a/dev.bat
+++ b/dev.bat
@@ -2,6 +2,13 @@
 
 dotnet build
 
-wt -d "Maple2.Server.World" --title "World Server" dotnet run --no-build ; ^
-sp -d "Maple2.Server.Login" --title "Login Server" dotnet run --no-build ; ^
-sp -d "Maple2.Server.Web" --title "Web Server" dotnet run --no-build
+where wt >nul 2>&1
+if %errorlevel%==0 (
+    wt -d "Maple2.Server.World" --title "World Server" dotnet run --no-build ; ^
+    sp -d "Maple2.Server.Login" --title "Login Server" dotnet run --no-build ; ^
+    sp -d "Maple2.Server.Web" --title "Web Server" dotnet run --no-build
+) else (
+    start "World Server" /d "Maple2.Server.World" cmd /k dotnet run --no-build
+    start "Login Server" /d "Maple2.Server.Login" cmd /k dotnet run --no-build
+    start "Web Server" /d "Maple2.Server.Web" cmd /k dotnet run --no-build
+)

--- a/start.bat
+++ b/start.bat
@@ -2,7 +2,15 @@
 
 dotnet build
 
-wt -d "Maple2.Server.World" --title "World Server" dotnet run --no-build ; ^
-nt -d "Maple2.Server.Login" --title "Login Server" dotnet run --no-build ; ^
-nt -d "Maple2.Server.Web" --title "Web Server" dotnet run --no-build ; ^
-nt -d "Maple2.Server.Game" --title "Game Server" dotnet run --no-build
+where wt >nul 2>&1
+if %errorlevel%==0 (
+    wt -d "Maple2.Server.World" --title "World Server" dotnet run --no-build ; ^
+    nt -d "Maple2.Server.Login" --title "Login Server" dotnet run --no-build ; ^
+    nt -d "Maple2.Server.Web" --title "Web Server" dotnet run --no-build ; ^
+    nt -d "Maple2.Server.Game" --title "Game Server" dotnet run --no-build
+) else (
+    start "World Server" /d "Maple2.Server.World" cmd /k dotnet run --no-build
+    start "Login Server" /d "Maple2.Server.Login" cmd /k dotnet run --no-build
+    start "Web Server" /d "Maple2.Server.Web" cmd /k dotnet run --no-build
+    start "Game Server" /d "Maple2.Server.Game" cmd /k dotnet run --no-build
+)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved server startup scripts to automatically detect and use Windows Terminal if available, or fall back to classic Command Prompt windows if not.
  - Enhanced compatibility for starting multiple server projects across different Windows environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->