### PR TITLE
Sync Skills & State Skills & Misc

### DIFF
--- a/Maple2.Database/Storage/Metadata/QuestMetadataStorage.cs
+++ b/Maple2.Database/Storage/Metadata/QuestMetadataStorage.cs
@@ -61,6 +61,10 @@ public class QuestMetadataStorage(MetadataContext context) : MetadataStorage<int
         return GetQuests().Where(x => x.Basic.Type == type);
     }
 
+    public IEnumerable<QuestMetadata> GetQuestsByChapter(int chapterId) {
+        return GetQuests().Where(x => x.Basic.ChapterId == chapterId);
+    }
+
     public List<QuestMetadata> Search(string name) {
         return GetQuests().Where(x => x.Name != null && x.Name.Contains(name, StringComparison.OrdinalIgnoreCase)).ToList();
     }

--- a/Maple2.File.Ingest/Mapper/AdditionalEffectMapper.cs
+++ b/Maple2.File.Ingest/Mapper/AdditionalEffectMapper.cs
@@ -158,13 +158,13 @@ public class AdditionalEffectMapper : TypeMapper<AdditionalEffectMetadata> {
         resistances.AddIfNotDefault(BasicAttribute.AttackSpeed, status.resAspR);
 
         Debug.Assert(status.compulsionEventTypes.Length <= 1 && status.compulsionEventRate.Length <= 1);
-        var compulsionEventType = CompulsionEventType.None;
+        var compulsionEventType = BuffCompulsionEventType.None;
         if (status.compulsionEventTypes.Length > 0) {
-            compulsionEventType = (CompulsionEventType) status.compulsionEventTypes[0];
+            compulsionEventType = (BuffCompulsionEventType) status.compulsionEventTypes[0];
         }
 
         AdditionalEffectMetadataStatus.CompulsionEvent? compulsionEvent = null;
-        if (compulsionEventType != CompulsionEventType.None) {
+        if (compulsionEventType != BuffCompulsionEventType.None) {
             float compulsionEventRate = 0;
             if (status.compulsionEventRate.Length > 0) {
                 compulsionEventRate = status.compulsionEventRate[0];

--- a/Maple2.File.Ingest/Mapper/SkillMapper.cs
+++ b/Maple2.File.Ingest/Mapper/SkillMapper.cs
@@ -1,4 +1,6 @@
-﻿using System.Diagnostics;
+﻿using System.ComponentModel;
+using System.Diagnostics;
+using System.Reflection;
 using Maple2.File.IO;
 using Maple2.File.Parser;
 using Maple2.File.Parser.Xml.Skill;
@@ -15,9 +17,12 @@ public class SkillMapper : TypeMapper<StoredSkillMetadata> {
     }
 
     protected override IEnumerable<StoredSkillMetadata> Map() {
+        List<long> magicPaths = [];
+        List<long> cubeMagicPaths = [];
         foreach ((int id, string name, SkillData data) in parser.Parse()) {
             if (data.basic == null) continue; // Old_JobChange_01
             Debug.Assert(data.basic.kinds.groupIDs.Length <= 1);
+
 
             // Note: 90000775 has cubeMagicPathID="2147483647" which should be cubeMagicPathID="9000073111"
             Dictionary<short, SkillMetadataLevel> levels = data.level.ToDictionary(
@@ -65,7 +70,7 @@ public class SkillMapper : TypeMapper<StoredSkillMetadata> {
                                 Explosion: attack.arrowProperty.explosion,
                                 RayPhysXTest: attack.arrowProperty.rayPhysxTest,
                                 NonTarget: (SkillTargetType) attack.arrowProperty.nonTarget,
-                                BounceType: attack.arrowProperty.bounceType,
+                                BounceType: (BounceType) attack.arrowProperty.bounceType,
                                 BounceCount: attack.arrowProperty.bounceCount,
                                 BounceRadius: attack.arrowProperty.bounceRadius,
                                 BounceOverlap: attack.arrowProperty.bounceType > 0 && attack.arrowProperty.bounceOverlap,
@@ -111,7 +116,14 @@ public class SkillMapper : TypeMapper<StoredSkillMetadata> {
                     RangeType: (RangeType) data.basic.kinds.rangeType,
                     AttackType: (AttackType) data.basic.ui.attackType,
                     Element: (Element) data.basic.kinds.element,
-                    State: Enum.TryParse(data.basic.kinds.state, true, out ActorState state) ? state : ActorState.None,
+                    State: string.IsNullOrEmpty(data.basic.kinds.state)
+                        ? ActorState.None
+                        : Enum.GetValues<ActorState>()
+                            .FirstOrDefault(enumValue =>
+                                enumValue.GetType()
+                                    .GetField(enumValue.ToString())
+                                    ?.GetCustomAttribute<DescriptionAttribute>()
+                                    ?.Description == data.basic.kinds.state),
                     ContinueSkill: data.basic.kinds.continueSkill,
                     SpRecoverySkill: data.basic.kinds.spRecoverySkill,
                     ImmediateActive: data.basic.kinds.immediateActive,
@@ -123,7 +135,7 @@ public class SkillMapper : TypeMapper<StoredSkillMetadata> {
                     MaxLevel: levels.Keys.Max()),
                 State: new SkillMetadataState(
                     InBattle: data.basic.stateAttr.battle == 1,
-                    SuperArmor: data.basic.stateAttr.superArmor,
+                    SuperArmor: (SuperArmor) data.basic.stateAttr.superArmor,
                     UseInGameTime: data.basic.stateAttr.useInGameTime == 1,
                     IgnoreReduceCooldown: data.basic.stateAttr.ignoreReduceCooldown == 1,
                     CooldownGroupId: data.basic.stateAttr.cooldownGroupID,
@@ -138,6 +150,7 @@ public class SkillMapper : TypeMapper<StoredSkillMetadata> {
             Type: region.rangeType switch {
                 "box" => SkillRegion.Box,
                 "cylinder" => SkillRegion.Cylinder,
+                "circle" => SkillRegion.Cylinder,
                 "frustum" => SkillRegion.Frustum,
                 "hole_cylinder" => SkillRegion.HoleCylinder,
                 "1200" => SkillRegion.None, // skill/60/60012051.xml

--- a/Maple2.Model/Enum/Buff.cs
+++ b/Maple2.Model/Enum/Buff.cs
@@ -32,7 +32,7 @@ public enum BuffCategory {
     Unknown4 = 4,
     EnemyDot = 6,
     Stunned = 7, // ?
-    Slow = 8, // ?
+    Slow = 8,
     BossResistance = 9,
     Unknown99 = 99,
     MonsterStunned = 1007, // ?
@@ -90,4 +90,11 @@ public enum InvokeEffectType : byte {
     ReduceSpiritCost = 56,
     // 57 (90050351) // Triggered from 10500061 (Sharp Eyes) -
     IncreaseHealing = 58,
+}
+
+public enum BuffCompulsionEventType : byte {
+    None = 0,
+    CritChanceOverride = 1,
+    EvasionChanceOverride = 2,
+    BlockChance = 3,
 }

--- a/Maple2.Model/Enum/CompulsionEventType.cs
+++ b/Maple2.Model/Enum/CompulsionEventType.cs
@@ -1,8 +1,0 @@
-﻿namespace Maple2.Model.Enum;
-
-public enum CompulsionEventType : byte {
-    None = 0,
-    CritChanceOverride = 1,
-    EvasionChanceOverride = 2,
-    BlockChance = 3,
-}

--- a/Maple2.Model/Enum/Skill.cs
+++ b/Maple2.Model/Enum/Skill.cs
@@ -184,9 +184,9 @@ public enum EventConditionType {
 
 public enum CompulsionType {
     None = 0,
-    Critical = 1,
-    Evasion = 2,
-    Block = 3,
+    Hit = 1,
+    Critical = 2,
+    Interrupt = 3, // unconfirmed
 }
 
 public enum TargetType {
@@ -199,4 +199,20 @@ public enum TargetType {
     Player4 = 7, // Unknown, Debuff (Archeon's ice bombs)
 
     HungryMobs = 8
+}
+
+public enum BounceType {
+    None = 0,
+    Range = 1, // within range
+    Chain = 2, // Bounce continues as long as another entity is in range of the last bounce
+    Pierce = 3, // Linear
+    Boomerang = 4, // Shield Toss, Shadow Cutter
+    Unknown5 = 5,
+}
+
+[Flags]
+public enum SuperArmor {
+    None = 0,
+    StunImmunity = 1,
+    KnockbackImmunity = 2,
 }

--- a/Maple2.Model/Metadata/AdditionalEffectMetadata.cs
+++ b/Maple2.Model/Metadata/AdditionalEffectMetadata.cs
@@ -85,7 +85,7 @@ public record AdditionalEffectMetadataStatus(
     int ImmuneBreak,
     bool Invincible) {
 
-    public record CompulsionEvent(CompulsionEventType Type, float Rate, int[] SkillIds);
+    public record CompulsionEvent(BuffCompulsionEventType Type, float Rate, int[] SkillIds);
 
     public record StatConversion(BasicAttribute BaseAttribute, BasicAttribute ResultAttribute, float Rate);
 }

--- a/Maple2.Model/Metadata/Constants.cs
+++ b/Maple2.Model/Metadata/Constants.cs
@@ -102,6 +102,7 @@ public static class Constant {
     public const int Grade1WeddingCouponItemId = 20303166;
     public const int Grade2WeddingCouponItemId = 20303167;
     public const int Grade3WeddingCouponItemId = 20303168;
+    public const int MinStatIntervalTick = 100;
 
     public const int MaxMentees = 3;
 

--- a/Maple2.Model/Metadata/SkillMetadata.cs
+++ b/Maple2.Model/Metadata/SkillMetadata.cs
@@ -42,7 +42,7 @@ public record SkillMetadataProperty(
 
 public record SkillMetadataState(
     bool InBattle,
-    int SuperArmor,  // 0, 1, 3
+    SuperArmor SuperArmor,
     bool UseInGameTime,
     int CooldownGroupId,
     bool IgnoreReduceCooldown,
@@ -139,7 +139,7 @@ public record SkillMetadataArrow(
     bool Explosion,
     bool RayPhysXTest,
     SkillTargetType NonTarget,
-    int BounceType, // 2: chain, 3: pierce
+    BounceType BounceType,
     int BounceCount,
     float BounceRadius,
     bool BounceOverlap,

--- a/Maple2.Server.Game/Commands/PlayerCommand.cs
+++ b/Maple2.Server.Game/Commands/PlayerCommand.cs
@@ -157,10 +157,10 @@ public class PlayerCommand : GameCommand {
                 if (selectedJob == session.Player.Value.Character.Job) {
                     if (!awakening) {
                         // nothing to do
+                        ctx.ExitCode = 0;
                         return;
                     }
                     Awaken(ctx, jobCode);
-                    return;
                 } else {
                     if (awakening) {
                         Awaken(ctx, jobCode);

--- a/Maple2.Server.Game/Commands/PlayerCommand.cs
+++ b/Maple2.Server.Game/Commands/PlayerCommand.cs
@@ -83,7 +83,7 @@ public class PlayerCommand : GameCommand {
 
         private void Handle(InvocationContext ctx, long exp) {
             try {
-                session.Exp.AddExp(ExpType.none, exp);
+                session.Exp.AddExp(ExpType.expDrop, exp);
 
                 ctx.ExitCode = 0;
             } catch (SystemException ex) {
@@ -138,51 +138,127 @@ public class PlayerCommand : GameCommand {
 
         private void Handle(InvocationContext ctx, JobCode jobCode, bool awakening) {
             try {
-                Job job = jobCode switch {
+                Job selectedJob = jobCode switch {
                     JobCode.Newbie => Job.Newbie,
-                    JobCode.Knight => awakening ? Job.KnightII : Job.Knight,
-                    JobCode.Berserker => awakening ? Job.BerserkerII : Job.Berserker,
-                    JobCode.Wizard => awakening ? Job.WizardII : Job.Wizard,
-                    JobCode.Priest => awakening ? Job.PriestII : Job.Priest,
-                    JobCode.Archer => awakening ? Job.ArcherII : Job.Archer,
-                    JobCode.HeavyGunner => awakening ? Job.HeavyGunnerII : Job.HeavyGunner,
-                    JobCode.Thief => awakening ? Job.ThiefII : Job.Thief,
-                    JobCode.Assassin => awakening ? Job.AssassinII : Job.Assassin,
-                    JobCode.RuneBlader => awakening ? Job.RuneBladerII : Job.RuneBlader,
-                    JobCode.Striker => awakening ? Job.StrikerII : Job.Striker,
-                    JobCode.SoulBinder => awakening ? Job.SoulBinderII : Job.SoulBinder,
-                    _ => throw new ArgumentException($"Invalid JobCode: {jobCode}")
+                    JobCode.Knight => Job.Knight,
+                    JobCode.Berserker => Job.Berserker,
+                    JobCode.Wizard => Job.Wizard,
+                    JobCode.Priest => Job.Priest,
+                    JobCode.Archer => Job.Archer,
+                    JobCode.HeavyGunner => Job.HeavyGunner,
+                    JobCode.Thief => Job.Thief,
+                    JobCode.Assassin => Job.Assassin,
+                    JobCode.RuneBlader => Job.RuneBlader,
+                    JobCode.Striker => Job.Striker,
+                    JobCode.SoulBinder => Job.SoulBinder,
+                    _ => throw new ArgumentException($"Invalid JobCode: {jobCode}"),
                 };
 
-                Job currentJob = session.Player.Value.Character.Job;
-                if (currentJob.Code() != job.Code()) {
-                    foreach (SkillTab skillTab in session.Config.Skill.SkillBook.SkillTabs) {
-                        skillTab.Skills.Clear();
+                if (selectedJob == session.Player.Value.Character.Job) {
+                    if (!awakening) {
+                        // nothing to do
+                        return;
                     }
-                } else if (job < currentJob) {
-                    foreach (SkillTab skillTab in session.Config.Skill.SkillBook.SkillTabs) {
-                        foreach (int skillId in skillTab.Skills.Keys.ToList()) {
-                            if (session.Config.Skill.SkillInfo.GetMainSkill(skillId, SkillRank.Awakening) != null) {
-                                skillTab.Skills.Remove(skillId);
-                            }
-                        }
+                    Awaken(ctx, jobCode);
+                    return;
+                } else {
+                    if (awakening) {
+                        Awaken(ctx, jobCode);
+                    } else {
+                        JobAdvance(selectedJob);
                     }
-                    session.Config.Skill.ResetSkills(SkillRank.Awakening);
                 }
-
-                session.Player.Value.Character.Job = job;
-                session.Config.Skill.SkillInfo.SetJob(job);
-
-                session.Player.Buffs.Clear();
-                session.Player.Buffs.Initialize();
-                session.Player.Buffs.LoadFieldBuffs();
-                session.Stats.Refresh();
-                session.Field?.Broadcast(JobPacket.Advance(session.Player, session.Config.Skill.SkillInfo));
                 ctx.ExitCode = 0;
             } catch (SystemException ex) {
                 ctx.Console.Error.WriteLine(ex.Message);
                 ctx.ExitCode = 1;
             }
+        }
+
+        private void Awaken(InvocationContext ctx, JobCode jobCode) {
+            Job awakenedJob = jobCode switch {
+                JobCode.Newbie => Job.Newbie,
+                JobCode.Knight => Job.KnightII,
+                JobCode.Berserker => Job.BerserkerII,
+                JobCode.Wizard => Job.WizardII,
+                JobCode.Priest => Job.PriestII,
+                JobCode.Archer => Job.ArcherII,
+                JobCode.HeavyGunner => Job.HeavyGunnerII,
+                JobCode.Thief => Job.ThiefII,
+                JobCode.Assassin => Job.AssassinII,
+                JobCode.RuneBlader => Job.RuneBladerII,
+                JobCode.Striker => Job.StrikerII,
+                JobCode.SoulBinder => Job.SoulBinderII,
+                _ => throw new ArgumentException($"Invalid JobCode: {jobCode}"),
+            };
+            Job baseJob = jobCode switch {
+                JobCode.Newbie => Job.Newbie,
+                JobCode.Knight => Job.Knight,
+                JobCode.Berserker => Job.Berserker,
+                JobCode.Wizard => Job.Wizard,
+                JobCode.Priest => Job.Priest,
+                JobCode.Archer => Job.Archer,
+                JobCode.HeavyGunner => Job.HeavyGunner,
+                JobCode.Thief => Job.Thief,
+                JobCode.Assassin => Job.Assassin,
+                JobCode.RuneBlader => Job.RuneBlader,
+                JobCode.Striker => Job.Striker,
+                JobCode.SoulBinder => Job.SoulBinder,
+                _ => throw new ArgumentException($"Invalid JobCode: {jobCode}"),
+            };
+
+            if (!session.TableMetadata.ChangeJobTable.Entries.TryGetValue(baseJob, out ChangeJobMetadata? changeJobMetadata)) {
+                ctx.Console.Error.WriteLine($"Invalid JobCode: {jobCode}");
+                return;
+            }
+
+            if (!session.QuestMetadata.TryGet(changeJobMetadata.StartQuestId, out QuestMetadata? startQuestMetadata)) {
+                ctx.Console.Error.WriteLine($"Invalid StartQuestId for awakening: {changeJobMetadata.StartQuestId}");
+                return;
+            }
+            session.Quest.DebugCompleteChapter(startQuestMetadata.Basic.ChapterId);
+            JobAdvance(awakenedJob);
+            UnlockMasterSkills();
+        }
+
+        private void JobAdvance(Job job) {
+            Job currentJob = session.Player.Value.Character.Job;
+            if (currentJob.Code() != job.Code()) {
+                foreach (SkillTab skillTab in session.Config.Skill.SkillBook.SkillTabs) {
+                    skillTab.Skills.Clear();
+                }
+            } else if (job < currentJob) {
+                foreach (SkillTab skillTab in session.Config.Skill.SkillBook.SkillTabs) {
+                    foreach (int skillId in skillTab.Skills.Keys.ToList()) {
+                        if (session.Config.Skill.SkillInfo.GetMainSkill(skillId, SkillRank.Awakening) != null) {
+                            skillTab.Skills.Remove(skillId);
+                        }
+                    }
+                }
+                session.Config.Skill.ResetSkills(SkillRank.Awakening);
+            }
+
+            session.Player.Value.Character.Job = job;
+            session.Config.Skill.SkillInfo.SetJob(job);
+
+            session.Player.Buffs.Clear();
+            session.Player.Buffs.Initialize();
+            session.Player.Buffs.LoadFieldBuffs();
+            session.Stats.Refresh();
+            session.Field?.Broadcast(JobPacket.Advance(session.Player, session.Config.Skill.SkillInfo));
+        }
+
+        private void UnlockMasterSkills() {
+            const int masterSkillQuestId = 40002795;
+            if (session.Quest.TryGetQuest(masterSkillQuestId, out Quest? quest) && quest.State == QuestState.Completed) {
+                return;
+            }
+
+            session.Quest.Start(masterSkillQuestId, true);
+            if (!session.Quest.TryGetQuest(masterSkillQuestId, out quest)) {
+                return;
+            }
+            session.Quest.Complete(quest, true);
         }
     }
 
@@ -424,21 +500,12 @@ public class PlayerCommand : GameCommand {
         }
 
         private void UnlockAllTrophies(InvocationContext ctx) {
-            try {
-                ICollection<AchievementMetadata> achievementMetadataCollection = achievementMetadataStorage.GetAll();
-                foreach (AchievementMetadata metadata in achievementMetadataCollection) {
-                    int trophyId = metadata.Id;
-                    int maxGrade = metadata.Grades.Keys.Max();
+            ctx.Console.Out.WriteLine($"Unlocking all trophies... This may take a few seconds");
+            session.Achievement.DebugCompleteAllTrophies();
+            session.Achievement.Load();
 
-                    UnlockTrophy(trophyId, metadata, maxGrade);
-                }
-
-                ctx.Console.Out.WriteLine("All trophies have been successfully unlocked to their maximum grades.");
-                ctx.ExitCode = 0;
-            } catch (Exception ex) {
-                ctx.Console.Error.WriteLine($"Failed to unlock all trophies: {ex.Message}");
-                ctx.ExitCode = 1;
-            }
+            ctx.Console.Out.WriteLine("All trophies have been successfully unlocked to their maximum grades.");
+            ctx.ExitCode = 0;
         }
 
         private void UnlockSingleTrophy(InvocationContext ctx, int trophyId, short grade) {

--- a/Maple2.Server.Game/Manager/AchievementManager.cs
+++ b/Maple2.Server.Game/Manager/AchievementManager.cs
@@ -261,9 +261,9 @@ public sealed class AchievementManager {
                     throw new InvalidOperationException($"Failed to create achievement: {metadata.Id}");
                 }
                 if (metadata.AccountWide) {
-                    accountValues.Add(metadata.Id, achievement);
+                    accountValues.TryAdd(metadata.Id, achievement);
                 } else {
-                    characterValues.Add(metadata.Id, achievement);
+                    characterValues.TryAdd(metadata.Id, achievement);
                 }
             }
 

--- a/Maple2.Server.Game/Manager/Config/BuffManager.cs
+++ b/Maple2.Server.Game/Manager/Config/BuffManager.cs
@@ -26,7 +26,7 @@ public class BuffManager : IUpdatable {
     public IActor Actor { get; private set; }
     private readonly ConcurrentDictionary<int, List<Buff>> buffs = [];
     public IDictionary<InvokeEffectType, IDictionary<int, InvokeRecord>> Invokes { get; init; }
-    public IDictionary<CompulsionEventType, IDictionary<int, AdditionalEffectMetadataStatus.CompulsionEvent>> Compulsions { get; init; }
+    public IDictionary<BuffCompulsionEventType, IDictionary<int, AdditionalEffectMetadataStatus.CompulsionEvent>> Compulsions { get; init; }
     private Dictionary<BasicAttribute, float> Resistances { get; } = new();
     public ConcurrentDictionary<int, long> CooldownTimes { get; } = new(); // TODO: Cache this
     public ReflectRecord? Reflect;
@@ -35,7 +35,7 @@ public class BuffManager : IUpdatable {
     public BuffManager(IActor actor) {
         Actor = actor;
         Invokes = new ConcurrentDictionary<InvokeEffectType, IDictionary<int, InvokeRecord>>();
-        Compulsions = new ConcurrentDictionary<CompulsionEventType, IDictionary<int, AdditionalEffectMetadataStatus.CompulsionEvent>>();
+        Compulsions = new ConcurrentDictionary<BuffCompulsionEventType, IDictionary<int, AdditionalEffectMetadataStatus.CompulsionEvent>>();
     }
 
     public void Initialize() {
@@ -156,8 +156,6 @@ public class BuffManager : IUpdatable {
         SetShield(buff);
         SetUpdates(buff);
         ModifyBuffStackCount(buff);
-
-        owner.ApplyEffects(buff.Metadata.Skills, caster, owner, type, skillId: id, buffId: id, targets: [owner]);
 
         // refresh stats if needed
         if (buff.Metadata.Status.Values.Any() || buff.Metadata.Status.Rates.Any() || buff.Metadata.Status.SpecialValues.Any() || buff.Metadata.Status.SpecialRates.Any()) {
@@ -286,7 +284,7 @@ public class BuffManager : IUpdatable {
             return;
         }
 
-        CompulsionEventType eventType = buff.Metadata.Status.Compulsion.Type;
+        BuffCompulsionEventType eventType = buff.Metadata.Status.Compulsion.Type;
         if (Compulsions.TryGetValue(eventType, out IDictionary<int, AdditionalEffectMetadataStatus.CompulsionEvent>? nestedCompulsionDic)) {
             Compulsions.RemoveAll(buff.Id);
 
@@ -301,7 +299,7 @@ public class BuffManager : IUpdatable {
         });
     }
 
-    public float TotalCompulsionRate(CompulsionEventType type, int skillId = 0) {
+    public float TotalCompulsionRate(BuffCompulsionEventType type, int skillId = 0) {
         if (!Compulsions.TryGetValue(type, out IDictionary<int, AdditionalEffectMetadataStatus.CompulsionEvent>? nestedCompulsionDic)) {
             return 0;
         }

--- a/Maple2.Server.Game/Manager/NpcScriptManager.cs
+++ b/Maple2.Server.Game/Manager/NpcScriptManager.cs
@@ -376,7 +376,7 @@ public sealed class NpcScriptManager {
         }
 
         if (!string.IsNullOrEmpty(scriptFunction.MoveMapMovie)) {
-            session.Send(NpcTalkPacket.Cutscene(scriptFunction.MoveMapMovie));
+            session.Send(NpcTalkPacket.Cutscene(scriptFunction.MoveMapMovie, scriptFunction.MoveMapId));
         }
 
         if (scriptFunction.PortalId > 0 && session.Field.TryGetPortal(scriptFunction.PortalId, out FieldPortal? dstPortal)) {

--- a/Maple2.Server.Game/Manager/StatsManager.cs
+++ b/Maple2.Server.Game/Manager/StatsManager.cs
@@ -180,8 +180,9 @@ public class StatsManager {
             foreach ((BasicAttribute valueBasicAttribute, long value) in buff.Metadata.Status.Values) {
                 Values[valueBasicAttribute].AddTotal(value);
             }
-            foreach ((BasicAttribute ratespecialAttribute, float rate) in buff.Metadata.Status.Rates) {
-                Values[ratespecialAttribute].AddRate(rate);
+            foreach ((BasicAttribute rateBasicAttribute, float rate) in buff.Metadata.Status.Rates) {
+                // ensure regen intervals do not drop below 0.1
+                Values[rateBasicAttribute].AddRate(rate);
             }
             foreach ((SpecialAttribute valueSpecialAttribute, float value) in buff.Metadata.Status.SpecialValues) {
                 Values[valueSpecialAttribute].AddTotal((long) value);

--- a/Maple2.Server.Game/Model/Field/Actor/Actor.cs
+++ b/Maple2.Server.Game/Model/Field/Actor/Actor.cs
@@ -325,7 +325,7 @@ public abstract class Actor<T> : IActor<T>, IDisposable {
         var record = new SkillRecord(metadata, uid, this) {
             Position = position == default ? Position : position,
             Rotation = Rotation == default ? Rotation : rotation,
-            Rotate2Z = 2 * Rotation.Z,
+            Rotate2Z = rotateZ,
             ServerTick = castTick,
         };
 

--- a/Maple2.Server.Game/Model/Field/Actor/ActorStateComponent/MovementStateTasks/MovementState.SkillCastTask.cs
+++ b/Maple2.Server.Game/Model/Field/Actor/ActorStateComponent/MovementStateTasks/MovementState.SkillCastTask.cs
@@ -89,7 +89,7 @@ public partial class MovementState {
 
         Velocity = new Vector3(0, 0, 0);
 
-        SkillRecord? cast = actor.CastSkill(id, level, uid, motion);
+        SkillRecord? cast = actor.CastSkill(id, level, uid, (int) actor.Field.FieldTick, motionPoint: motion);
 
         if (cast is null) {
             task.Cancel();

--- a/Maple2.Server.Game/Model/Field/Actor/FieldNpc.cs
+++ b/Maple2.Server.Game/Model/Field/Actor/FieldNpc.cs
@@ -366,7 +366,7 @@ public class FieldNpc : Actor<Npc> {
 
         Field.Broadcast(NpcControlPacket.Control(this));
 
-        return base.CastSkill(id, level, uid, castTick, position,  direction, rotation, rotateZ, motionPoint);
+        return base.CastSkill(id, level, uid, castTick, position, direction, rotation, rotateZ, motionPoint);
     }
 
     public NpcTask CastAiSkill(int id, short level, int faceTarget, Vector3 facePos, long uid = 0) {

--- a/Maple2.Server.Game/Model/Field/Actor/FieldNpc.cs
+++ b/Maple2.Server.Game/Model/Field/Actor/FieldNpc.cs
@@ -353,7 +353,7 @@ public class FieldNpc : Actor<Npc> {
         }
     }
 
-    public override SkillRecord? CastSkill(int id, short level, long uid = 0, byte motionPoint = 0) {
+    public override SkillRecord? CastSkill(int id, short level, long uid, int castTick, in Vector3 position = default, in Vector3 direction = default, in Vector3 rotation = default, float rotateZ = 0f, byte motionPoint = 0) {
         if (!Field.SkillMetadata.TryGet(id, level, out SkillMetadata? metadata) || metadata.Data.Motions.Length <= motionPoint) {
             Logger.Error("Invalid skill use: {SkillId},{Level},{motionPoint}", id, level, motionPoint);
             return null;
@@ -361,13 +361,12 @@ public class FieldNpc : Actor<Npc> {
 
         if (uid == 0) {
             // The client derives the player's skill cast skillSn/uid using this formula so I'm using it here for mob casts for parity.
-            uid = (long) ((DateTime.UtcNow - new DateTime(1970, 1, 1)).TotalSeconds * 100000) % (long) 1e14;
+            uid = (long) NextLocalId() << 32 | (uint) Environment.TickCount;
         }
 
         Field.Broadcast(NpcControlPacket.Control(this));
 
-        var cast = base.CastSkill(id, level, uid, motionPoint);
-
+        SkillRecord? cast = base.CastSkill(id, level, uid, castTick, motionPoint: motionPoint);
         return cast;
     }
 

--- a/Maple2.Server.Game/Model/Field/Actor/FieldNpc.cs
+++ b/Maple2.Server.Game/Model/Field/Actor/FieldNpc.cs
@@ -366,8 +366,7 @@ public class FieldNpc : Actor<Npc> {
 
         Field.Broadcast(NpcControlPacket.Control(this));
 
-        SkillRecord? cast = base.CastSkill(id, level, uid, castTick, motionPoint: motionPoint);
-        return cast;
+        return base.CastSkill(id, level, uid, castTick, position,  direction, rotation, rotateZ, motionPoint);
     }
 
     public NpcTask CastAiSkill(int id, short level, int faceTarget, Vector3 facePos, long uid = 0) {

--- a/Maple2.Server.Game/Model/Field/Actor/FieldPlayer.cs
+++ b/Maple2.Server.Game/Model/Field/Actor/FieldPlayer.cs
@@ -221,7 +221,7 @@ public class FieldPlayer : Actor<Player> {
                 return;
             }
 
-            stateSkill.StateNextTick = tickCount + (int) TimeSpan.FromSeconds(stateSkill.Motion.MotionProperty.SequenceSpeed).TotalMilliseconds;
+            stateSkill.StateNextTick = tickCount + (int) TimeSpan.FromSeconds(Math.Max(0.01f, stateSkill.Motion.MotionProperty.SequenceSpeed)).TotalMilliseconds;
             if (!SkillCastConsume(stateSkill)) {
                 ActiveSkills.StateSkill = null;
                 Field.Broadcast(SkillPacket.Cancel(stateSkill));

--- a/Maple2.Server.Game/Model/Field/Actor/FieldPlayer.cs
+++ b/Maple2.Server.Game/Model/Field/Actor/FieldPlayer.cs
@@ -163,8 +163,6 @@ public class FieldPlayer : Actor<Player> {
             InBattle = false;
         }
 
-        //Console.WriteLine($"State: {State}");
-
         UpdateStateSkill();
 
         if (IsDead) {

--- a/Maple2.Server.Game/Model/Field/Actor/FieldPlayer.cs
+++ b/Maple2.Server.Game/Model/Field/Actor/FieldPlayer.cs
@@ -64,6 +64,7 @@ public class FieldPlayer : Actor<Player> {
     private long StateSyncTrackingTick { get; set; }
 
     public Tombstone? Tombstone { get; set; }
+
     public DeathState DeathState {
         get => Value.Character.DeathState;
         set {
@@ -140,6 +141,7 @@ public class FieldPlayer : Actor<Player> {
 
     public override void Update(long tickCount) {
         base.Update(tickCount);
+        Session.GameEvent.Update(tickCount);
 
         if (Flag != PlayerObjectFlag.None && tickCount > flagTick) {
             Field.Broadcast(ProxyObjectPacket.UpdatePlayer(this, Flag));
@@ -161,44 +163,72 @@ public class FieldPlayer : Actor<Player> {
             InBattle = false;
         }
 
-        if (!IsDead) {
-            // Loops through each registered regen stat and applies regen
-            var statsToRemove = new List<BasicAttribute>();
-            foreach (BasicAttribute attribute in regenStats.Keys) {
-                Stat stat = Stats.Values[attribute];
-                Stat regen = Stats.Values[regenStats[attribute].Item1];
-                Stat interval = Stats.Values[regenStats[attribute].Item2];
+        //Console.WriteLine($"State: {State}");
 
-                if (stat.Current >= stat.Total) {
-                    // Removes stat from regen stats so it won't be listened for
-                    statsToRemove.Add(attribute);
-                    continue;
-                }
+        UpdateStateSkill();
 
-                lastRegenTime.TryGetValue(attribute, out long regenTime);
+        if (IsDead) {
+            return;
+        }
+        // Loops through each registered regen stat and applies regen
+        var statsToRemove = new List<BasicAttribute>();
+        foreach (BasicAttribute attribute in regenStats.Keys) {
+            Stat stat = Stats.Values[attribute];
+            Stat regen = Stats.Values[regenStats[attribute].Item1];
+            Stat interval = Stats.Values[regenStats[attribute].Item2];
 
-                if (tickCount - regenTime > interval.Base) {
-                    lastRegenTime[attribute] = tickCount;
-                    switch (attribute) {
-                        case BasicAttribute.Health:
-                            RecoverHp((int) regen.Total);
-                            continue;
-                        case BasicAttribute.Spirit:
-                            RecoverSp((int) regen.Total);
-                            continue;
-                        case BasicAttribute.Stamina:
-                            RecoverStamina((int) regen.Total);
-                            continue;
-                    }
-                    Session.Send(StatsPacket.Update(this, attribute));
-                }
+            if (stat.Current >= stat.Total) {
+                // Removes stat from regen stats so it won't be listened for
+                statsToRemove.Add(attribute);
+                continue;
             }
-            foreach (BasicAttribute attribute in statsToRemove) {
-                regenStats.Remove(attribute);
+
+            lastRegenTime.TryGetValue(attribute, out long regenTime);
+
+            if (tickCount - regenTime > Math.Max(interval.Current, Constant.MinStatIntervalTick)) {
+                lastRegenTime[attribute] = tickCount;
+                switch (attribute) {
+                    case BasicAttribute.Health:
+                        RecoverHp((int) regen.Total);
+                        continue;
+                    case BasicAttribute.Spirit:
+                        RecoverSp((int) regen.Total);
+                        continue;
+                    case BasicAttribute.Stamina:
+                        RecoverStamina((int) regen.Total);
+                        continue;
+                }
+                Session.Send(StatsPacket.Update(this, attribute));
             }
         }
+        foreach (BasicAttribute attribute in statsToRemove) {
+            regenStats.Remove(attribute);
+        }
+        CheckRegen();
+        return;
 
-        Session.GameEvent.Update(tickCount);
+        void UpdateStateSkill() {
+            SkillRecord? stateSkill = ActiveSkills.StateSkill;
+            if (stateSkill == null) {
+                return;
+            }
+
+            if (stateSkill.StateNextTick > tickCount) {
+                return;
+            }
+
+            if (stateSkill.Metadata.Property.State != State) {
+                Field.Broadcast(SkillPacket.Cancel(stateSkill));
+                ActiveSkills.StateSkill = null;
+                return;
+            }
+
+            stateSkill.StateNextTick = tickCount + (int) TimeSpan.FromSeconds(stateSkill.Motion.MotionProperty.SequenceSpeed).TotalMilliseconds;
+            if (!SkillCastConsume(stateSkill)) {
+                ActiveSkills.StateSkill = null;
+                Field.Broadcast(SkillPacket.Cancel(stateSkill));
+            }
+        }
     }
 
     public void OnStateSync(StateSync stateSync) {
@@ -512,19 +542,19 @@ public class FieldPlayer : Actor<Player> {
 
     public void CheckRegen() {
         // Health
-        var health = Stats.Values[BasicAttribute.Health];
+        Stat health = Stats.Values[BasicAttribute.Health];
         if (health.Current < health.Total && !regenStats.ContainsKey(BasicAttribute.Health)) {
             regenStats.Add(BasicAttribute.Health, new Tuple<BasicAttribute, BasicAttribute>(BasicAttribute.HpRegen, BasicAttribute.HpRegenInterval));
         }
 
         // Spirit
-        var spirit = Stats.Values[BasicAttribute.Spirit];
+        Stat spirit = Stats.Values[BasicAttribute.Spirit];
         if (spirit.Current < spirit.Total && !regenStats.ContainsKey(BasicAttribute.Spirit)) {
             regenStats.Add(BasicAttribute.Spirit, new Tuple<BasicAttribute, BasicAttribute>(BasicAttribute.SpRegen, BasicAttribute.SpRegenInterval));
         }
 
         // Stamina
-        var stamina = Stats.Values[BasicAttribute.Stamina];
+        Stat stamina = Stats.Values[BasicAttribute.Stamina];
         if (stamina.Current < stamina.Total && !regenStats.ContainsKey(BasicAttribute.Stamina)) {
             regenStats.Add(BasicAttribute.Stamina, new Tuple<BasicAttribute, BasicAttribute>(BasicAttribute.StaminaRegen, BasicAttribute.StaminaRegenInterval));
         }

--- a/Maple2.Server.Game/Model/Field/Actor/IActor.cs
+++ b/Maple2.Server.Game/Model/Field/Actor/IActor.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Concurrent;
+using System.Numerics;
 using Maple2.Database.Storage;
 using Maple2.Model.Enum;
 using Maple2.Model.Metadata;
@@ -11,7 +12,6 @@ using Maple2.Tools.Collision;
 namespace Maple2.Server.Game.Model;
 
 public interface IActor : IFieldEntity {
-    protected static readonly ConcurrentDictionary<int, Buff> NoBuffs = new();
     public NpcMetadataStorage? NpcMetadata { get; init; }
     public BuffManager Buffs { get; }
 
@@ -31,7 +31,7 @@ public interface IActor : IFieldEntity {
 
     public virtual void TargetAttack(SkillRecord record) { }
 
-    public virtual SkillRecord? CastSkill(int id, short level, long uid = 0, byte motionPoint = 0) { return null; }
+    public virtual SkillRecord? CastSkill(int id, short level, long uid, int castTick, in Vector3 position = default, in Vector3 direction = default, in Vector3 rotation = default, float rotateZ = 0f, byte motionPoint = 0) { return null; }
     public virtual void KeyframeEvent(string keyName) { }
 }
 

--- a/Maple2.Server.Game/Model/Skill/SkillQueue.cs
+++ b/Maple2.Server.Game/Model/Skill/SkillQueue.cs
@@ -1,4 +1,6 @@
-﻿namespace Maple2.Server.Game.Model.Skill;
+﻿using Maple2.Model.Enum;
+
+namespace Maple2.Server.Game.Model.Skill;
 
 // Used to keep track and lookup pending skills
 // This is a circular array and will overwrite old pending skills
@@ -6,6 +8,7 @@ public class SkillQueue {
     private const int MAX_PENDING = 3;
 
     private readonly SkillRecord?[] casts;
+    public SkillRecord? StateSkill;
     private int index;
 
     public SkillQueue() {
@@ -15,6 +18,10 @@ public class SkillQueue {
 
     public void Add(SkillRecord cast) {
         casts[index] = cast;
+
+        if (cast.Metadata.Property.State != ActorState.None) {
+            StateSkill = cast;
+        }
 
         index = (index + 1) % MAX_PENDING;
     }

--- a/Maple2.Server.Game/Model/Skill/SkillRecord.cs
+++ b/Maple2.Server.Game/Model/Skill/SkillRecord.cs
@@ -32,6 +32,8 @@ public class SkillRecord {
     public string HoldString = string.Empty;
     public long ItemUid;
 
+    public long StateNextTick; // Used for state skills only
+
     public ConcurrentDictionary<int, IActor> Targets;
 
     public SkillRecord(SkillMetadata metadata, long castUid, IActor caster) {

--- a/Maple2.Server.Game/Model/Stats.cs
+++ b/Maple2.Server.Game/Model/Stats.cs
@@ -167,14 +167,14 @@ public sealed class Stat {
     }
 
     public void AddBase(long amount) {
-        Total += amount;
-        Base += amount;
-        Current += amount;
+        Total = Math.Max(0, Total + amount);
+        Base = Math.Max(0, Base + amount);
+        Current = Math.Max(0, Current + amount);
     }
 
     public void AddTotal(long amount) {
-        Total += amount;
-        Current += amount;
+        Total = Math.Max(0, Total + amount);
+        Current = Math.Max(0, Current + amount);
     }
 
     public void AddTotal(BasicOption option) {

--- a/Maple2.Server.Game/Packets/NpcTalkPacket.cs
+++ b/Maple2.Server.Game/Packets/NpcTalkPacket.cs
@@ -98,10 +98,11 @@ public static class NpcTalkPacket {
         return pWriter;
     }
 
-    public static ByteWriter Cutscene(string movieString) {
+    public static ByteWriter Cutscene(string movieString, int mapId) {
         var pWriter = Packet.Of(SendOp.NpcTalk);
         pWriter.Write<Command>(Command.Action);
         pWriter.Write<NpcTalkAction>(NpcTalkAction.Cutscene);
+        pWriter.WriteInt(mapId);
         pWriter.WriteUnicodeString(movieString);
 
         return pWriter;

--- a/Maple2.Server.Game/Service/ChannelService.Heartbeat.cs
+++ b/Maple2.Server.Game/Service/ChannelService.Heartbeat.cs
@@ -1,16 +1,23 @@
 ﻿using Grpc.Core;
 using Maple2.Server.Core.Packets;
 using Maple2.Server.Game.Session;
+using Serilog;
 
 namespace Maple2.Server.Game.Service;
 
 public partial class ChannelService {
     public override Task<HeartbeatResponse> Heartbeat(HeartbeatRequest request, ServerCallContext context) {
         if (request.CharacterId == 0) {
-            throw new RpcException(new Status(StatusCode.NotFound, "Character ID is 0."));
+            Log.Warning("Heartbeat from unknown session. No character id.");
+            return Task.FromResult(new HeartbeatResponse {
+                Success = false,
+            });
         }
         if (!server.GetSession(request.CharacterId, out GameSession? session)) {
-            throw new RpcException(new Status(StatusCode.NotFound, "Session not found."));
+            Log.Warning("Heartbeat from unknown session: {CharacterId}", request.CharacterId);
+            return Task.FromResult(new HeartbeatResponse {
+                Success = false,
+            });
         }
 
         session.Send(RequestPacket.Heartbeat());

--- a/Maple2.Server.Game/Util/DamageCalculator.cs
+++ b/Maple2.Server.Game/Util/DamageCalculator.cs
@@ -10,12 +10,12 @@ namespace Maple2.Server.Game.Util;
 public static class DamageCalculator {
     public static (DamageType, long) CalculateDamage(IActor caster, IActor target, DamagePropertyRecord property) {
         // Check block
-        if (Damage.TriggerCompulsionEvent(target.Buffs.TotalCompulsionRate(CompulsionEventType.BlockChance, property.SkillId))) {
+        if (Damage.TriggerCompulsionEvent(target.Buffs.TotalCompulsionRate(BuffCompulsionEventType.BlockChance, property.SkillId))) {
             return (DamageType.Block, 0);
         }
 
         // Check evase
-        if (Damage.TriggerCompulsionEvent(target.Buffs.TotalCompulsionRate(CompulsionEventType.EvasionChanceOverride, property.SkillId))) {
+        if (Damage.TriggerCompulsionEvent(target.Buffs.TotalCompulsionRate(BuffCompulsionEventType.EvasionChanceOverride, property.SkillId))) {
             return (DamageType.Miss, 0);
         }
 
@@ -80,7 +80,7 @@ public static class DamageCalculator {
             }
 
             if (damageType != DamageType.Critical) {
-                damageType = caster.Stats.GetCriticalRate(target.Stats.Values[BasicAttribute.CriticalEvasion].Total, caster.Buffs.TotalCompulsionRate(CompulsionEventType.CritChanceOverride, property.SkillId));
+                damageType = caster.Stats.GetCriticalRate(target.Stats.Values[BasicAttribute.CriticalEvasion].Total, caster.Buffs.TotalCompulsionRate(BuffCompulsionEventType.CritChanceOverride, property.SkillId));
             }
         }
 

--- a/Maple2.Server.World/Migrations/20250304061437_InteractCubeFix.cs
+++ b/Maple2.Server.World/Migrations/20250304061437_InteractCubeFix.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿using Maple2.Server.Core.Constants;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
@@ -7,8 +8,9 @@ namespace Maple2.Server.World.Migrations {
     public partial class InteractCubeFix : Migration {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder) {
-            migrationBuilder.Sql("DELETE FROM `game-server`.`ugcmap-cube` WHERE `Interact` IS NOT NULL AND `Interact` <> '';");
-            migrationBuilder.Sql("DELETE FROM `game-server`.`home-layout-cube` WHERE `Interact` IS NOT NULL AND `Interact` <> '';");
+            var dbName = Environment.GetEnvironmentVariable("GaME_DB_NAME");
+            migrationBuilder.Sql($"DELETE FROM `{dbName}`.`ugcmap-cube` WHERE `Interact` IS NOT NULL AND `Interact` <> '';");
+            migrationBuilder.Sql($"DELETE FROM `{dbName}`.`home-layout-cube` WHERE `Interact` IS NOT NULL AND `Interact` <> '';");
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
- Fixed sync skill casting and looping
- Fixed State skills (really just fast swimming)
- Improved job command. Will now complete the awakening quest line and the master skill quest line
- Improved trophy command. Using it to unlock all trophies should now unlock ALL trophies
- Fixed exp command not giving exp
- Fixed RB's Rune Balance not giving proper SP on tick.
- Minor adjustments on buffs. This might break some skills in the meantime but once region skills are properly implemented, this will make more sense.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added commands and methods to instantly complete all quests in a chapter and unlock all trophies for debugging purposes.
  - Introduced new enums and constants for skill and buff categorization, including bounce types and super armor states.
  - Enhanced skill casting and handling, including new parameters for skill position, timing, and direction.
  - Added tracking for state-related skills in skill queue and skill records.
  - Added method to retrieve quests by chapter.

- **Improvements**
  - Refined job advancement and awakening commands for clearer flow and validation.
  - Improved stat regeneration logic and ensured stats cannot become negative.
  - Updated skill and buff systems to use more descriptive and strongly typed enums.
  - Enhanced cutscene handling to include map identifiers.
  - Reorganized player update flow to better handle state skills and regeneration.
  - Improved skill consumption and synchronization logic in handlers.
  - Simplified buff management by updating compulsion event types.
  - Enhanced NPC talk cutscene packets to include map IDs.

- **Bug Fixes**
  - Prevented negative stat values during updates.
  - Ensured regeneration intervals do not drop below a minimum threshold.
  - Added error logging for invalid motion points during skill casting.

- **Refactor**
  - Unified and renamed skill handler logic for clarity.
  - Simplified trophy unlocking and error handling in commands.
  - Streamlined error handling in channel heartbeat responses.
  - Replaced exception throwing with logging and graceful failure in heartbeat.
  - Updated enum references and removed deprecated enums for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->