### PR TITLE
Fix: Reroll Scrolls

### DIFF
--- a/Maple2.File.Ingest/Mapper/TableMapper.cs
+++ b/Maple2.File.Ingest/Mapper/TableMapper.cs
@@ -889,7 +889,10 @@ public class TableMapper : TypeMapper<TableMetadata> {
                 MinLevel: scroll.minLv,
                 MaxLevel: scroll.maxLv,
                 ItemTypes: scroll.slot,
-                Rarities: scroll.rank));
+                Rarities: scroll.rank,
+                RollAttribute: scroll.addOpKind == 1,
+                RollValueType: (RollValueType) scroll.addOpValue,
+                OnlyPet: scroll.onlyPet));
         }
 
         return new ItemRemakeScrollTable(results);

--- a/Maple2.Model/Metadata/Table/ScrollTable.cs
+++ b/Maple2.Model/Metadata/Table/ScrollTable.cs
@@ -14,7 +14,6 @@ public record EnchantScrollMetadata(
     int[] ItemTypes,
     int[] Rarities);
 
-
 public record ItemExchangeScrollTable(IReadOnlyDictionary<int, ItemExchangeScrollMetadata> Entries) : Table;
 
 public record ItemExchangeScrollMetadata(
@@ -30,8 +29,16 @@ public record ItemRemakeScrollMetadata(
     short MinLevel,
     short MaxLevel,
     int[] ItemTypes,
-    int[] Rarities);
+    int[] Rarities,
+    bool RollAttribute,
+    RollValueType RollValueType,
+    bool OnlyPet);
 
+public enum RollValueType {
+    None = 0,
+    Normal = 1,
+    HigherEnd = 2,
+}
 
 public record ItemRepackingScrollTable(IReadOnlyDictionary<int, ItemRepackingScrollMetadata> Entries) : Table;
 
@@ -41,7 +48,6 @@ public record ItemRepackingScrollMetadata(
     int[] ItemTypes,
     int[] Rarities,
     bool IsPet);
-
 
 public record ItemSocketScrollTable(IReadOnlyDictionary<int, ItemSocketScrollMetadata> Entries) : Table;
 

--- a/Maple2.Server.Game/PacketHandlers/ChangeAttributesHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/ChangeAttributesHandler.cs
@@ -61,7 +61,7 @@ public class ChangeAttributesHandler : PacketHandler<GameSession> {
 
         lock (session.Item) {
             // Validate item being changed + lock attributes/lock item if necessary.
-            Item? item = session.Item.Inventory.Get(itemUid, InventoryType.Gear)
+            Item? item = session.Item.GetGear(itemUid)
                          ?? session.Item.Inventory.Get(itemUid, InventoryType.Pets);
             if (item == null) {
                 session.Send(ChangeAttributesPacket.Error(s_itemremake_error_server_not_in_inven));
@@ -166,7 +166,7 @@ public class ChangeAttributesHandler : PacketHandler<GameSession> {
         }
 
         lock (session.Item) {
-            Item? item = session.Item.Inventory.Get(itemUid, InventoryType.Gear)
+            Item? item = session.Item.GetGear(itemUid)
                          ?? session.Item.Inventory.Get(itemUid, InventoryType.Pets);
             if (item == null) {
                 session.Send(ChangeAttributesPacket.Error(s_itemremake_error_server_not_in_inven));

--- a/Maple2.Server.Game/PacketHandlers/ChangeAttributesScrollHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/ChangeAttributesScrollHandler.cs
@@ -159,11 +159,6 @@ public class ChangeAttributesScrollHandler : PacketHandler<GameSession> {
                 }
             }
 
-            if (item.Metadata.Limit.TransferType is TransferType.BindPet) {
-                item.Transfer?.Bind(session.Player.Value.Character);
-                session.Send(ItemInventoryPacket.UpdateItem(item));
-            }
-
             // Try to consume both items.
             bool consumedScroll = session.Item.Inventory.Consume(scroll.Uid, 1);
             bool consumedLock = lockItem == null || session.Item.Inventory.Consume(lockItem.Uid, 1);
@@ -186,6 +181,11 @@ public class ChangeAttributesScrollHandler : PacketHandler<GameSession> {
                         : ChangeAttributesScrollError.s_itemremake_scroll_error_server_fail_consume_scroll
                 ));
                 return;
+            }
+
+            if (item.Metadata.Limit.TransferType is TransferType.BindPet) {
+                item.Transfer?.Bind(session.Player.Value.Character);
+                session.Send(ItemInventoryPacket.UpdateItem(item));
             }
 
             session.ChangeAttributesItem = changeItem;

--- a/Maple2.Server.Game/PacketHandlers/ChangeAttributesScrollHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/ChangeAttributesScrollHandler.cs
@@ -1,4 +1,5 @@
-﻿using Maple2.Database.Storage;
+﻿using System.Diagnostics.CodeAnalysis;
+using Maple2.Database.Storage;
 using Maple2.Model.Enum;
 using Maple2.Model.Error;
 using Maple2.Model.Game;
@@ -61,7 +62,7 @@ public class ChangeAttributesScrollHandler : PacketHandler<GameSession> {
                 return;
             }
 
-            Item? item = session.Item.Inventory.Get(itemUid, InventoryType.Gear);
+            Item? item = session.Item.Inventory.Get(itemUid, InventoryType.Gear) ?? session.Item.Inventory.Get(itemUid, InventoryType.Pets);
             if (item == null) {
                 session.Send(ChangeAttributesScrollPacket.Error(ChangeAttributesScrollError.s_itemremake_scroll_error_invalid_target_data));
                 return;
@@ -71,8 +72,8 @@ public class ChangeAttributesScrollHandler : PacketHandler<GameSession> {
                 return;
             }
 
-            ChangeAttributesScrollError error = IsCompatibleScroll(item, scroll);
-            if (error != ChangeAttributesScrollError.none) {
+            ChangeAttributesScrollError error = IsCompatibleScroll(item, scroll, out ItemRemakeScrollMetadata? itemRemakeScrollMetadata);
+            if (error is not ChangeAttributesScrollError.none || itemRemakeScrollMetadata is null) {
                 session.Send(ChangeAttributesScrollPacket.Error(error));
                 return;
             }
@@ -116,30 +117,74 @@ public class ChangeAttributesScrollHandler : PacketHandler<GameSession> {
                 return;
             }
 
-            ItemStats.Option changeOption = changeItem.Stats[ItemStats.Type.Random];
-            if (!ItemStatsCalc.RandomizeValues(changeItem, itemOptionMetadata, ref changeOption)) {
-                session.Send(ChangeAttributesScrollPacket.Error(ChangeAttributesScrollError.s_itemremake_scroll_error_server_fail_remake));
-                return;
-            }
-
-            // Restore locked attribute values.
-            if (lockItem != null) {
-                ItemStats.Option option = item.Stats[ItemStats.Type.Random];
-                if (isSpecialAttribute) {
-                    var specialAttribute = (SpecialAttribute) attribute;
-                    changeOption.Special[specialAttribute] = option.Special[specialAttribute];
+            if (itemRemakeScrollMetadata.RollAttribute) {
+                // Randomize attributes.
+                if (lockItem != null) {
+                    // Add back the locked attribute.
+                    if (isSpecialAttribute) {
+                        if (!ItemStatsCalc.UpdateRandomOption(ref changeItem, new LockOption((SpecialAttribute) attribute, true))) {
+                            session.Send(ChangeAttributesPacket.Error(ChangeAttributesError.s_itemremake_error_server_default));
+                            return;
+                        }
+                    } else {
+                        if (!ItemStatsCalc.UpdateRandomOption(ref changeItem, new LockOption((BasicAttribute) attribute, true))) {
+                            session.Send(ChangeAttributesPacket.Error(ChangeAttributesError.s_itemremake_error_server_default));
+                            return;
+                        }
+                    }
                 } else {
-                    var basicAttribute = (BasicAttribute) attribute;
-                    changeOption.Basic[basicAttribute] = option.Basic[basicAttribute];
+                    if (!ItemStatsCalc.UpdateRandomOption(ref changeItem)) {
+                        session.Send(ChangeAttributesPacket.Error(ChangeAttributesError.s_itemremake_error_server_default));
+                        return;
+                    }
+                }
+            } else {
+                ItemStats.Option changeOption = changeItem.Stats[ItemStats.Type.Random];
+
+                if (!ItemStatsCalc.RandomizeValues(changeItem, itemOptionMetadata, ref changeOption)) {
+                    session.Send(ChangeAttributesScrollPacket.Error(ChangeAttributesScrollError.s_itemremake_scroll_error_server_fail_remake));
+                    return;
+                }
+
+                // Restore locked attribute values.
+                if (lockItem != null) {
+                    ItemStats.Option option = item.Stats[ItemStats.Type.Random];
+                    if (isSpecialAttribute) {
+                        var specialAttribute = (SpecialAttribute) attribute;
+                        changeOption.Special[specialAttribute] = option.Special[specialAttribute];
+                    } else {
+                        var basicAttribute = (BasicAttribute) attribute;
+                        changeOption.Basic[basicAttribute] = option.Basic[basicAttribute];
+                    }
                 }
             }
 
-            if (!session.Item.Inventory.Consume(scroll.Uid, 1)) {
-                session.Send(ChangeAttributesScrollPacket.Error(ChangeAttributesScrollError.s_itemremake_scroll_error_server_fail_consume_scroll));
-                return;
+            if (item.Metadata.Limit.TransferType is TransferType.BindPet) {
+                item.Transfer?.Bind(session.Player.Value.Character);
+                session.Send(ItemInventoryPacket.UpdateItem(item));
             }
-            if (lockItem != null && !session.Item.Inventory.Consume(lockItem.Uid, 1)) {
-                session.Send(ChangeAttributesScrollPacket.Error(ChangeAttributesScrollError.s_itemremake_error_server_fail_lack_lock_consume_item));
+
+            // Try to consume both items.
+            bool consumedScroll = session.Item.Inventory.Consume(scroll.Uid, 1);
+            bool consumedLock = lockItem == null || session.Item.Inventory.Consume(lockItem.Uid, 1);
+
+            if (!consumedScroll || !consumedLock) {
+                // Rollback if either consumption failed.
+                if (consumedScroll) {
+                    Item newScroll = scroll.Clone();
+                    newScroll.Amount = 1;
+                    session.Item.Inventory.Add(newScroll); // Re-add scroll if only lock failed
+                }
+                if (lockItem != null && consumedLock) {
+                    Item newLockItem = lockItem.Clone();
+                    newLockItem.Amount = 1;
+                    session.Item.Inventory.Add(newLockItem); // Re-add lock item if only scroll failed
+                }
+                session.Send(ChangeAttributesScrollPacket.Error(
+                    consumedScroll
+                        ? ChangeAttributesScrollError.s_itemremake_error_server_fail_lack_lock_consume_item
+                        : ChangeAttributesScrollError.s_itemremake_scroll_error_server_fail_consume_scroll
+                ));
                 return;
             }
 
@@ -156,7 +201,7 @@ public class ChangeAttributesScrollHandler : PacketHandler<GameSession> {
         }
 
         lock (session.Item) {
-            Item? item = session.Item.Inventory.Get(itemUid, InventoryType.Gear);
+            Item? item = session.Item.Inventory.Get(itemUid, InventoryType.Gear) ?? session.Item.Inventory.Get(itemUid, InventoryType.Pets);
             if (item == null) {
                 session.Send(ChangeAttributesScrollPacket.Error(ChangeAttributesScrollError.s_itemremake_scroll_error_invalid_target_data));
                 return;
@@ -173,11 +218,12 @@ public class ChangeAttributesScrollHandler : PacketHandler<GameSession> {
         }
     }
 
-    private ChangeAttributesScrollError IsCompatibleScroll(Item item, Item scroll) {
+    private ChangeAttributesScrollError IsCompatibleScroll(Item item, Item scroll, out ItemRemakeScrollMetadata? metadata) {
+        metadata = null;
         if (item.Rarity is < Constant.ChangeAttributesMinRarity or > Constant.ChangeAttributesMaxRarity) {
             return ChangeAttributesScrollError.s_itemremake_scroll_error_impossible_rank;
         }
-        if (!item.Type.IsWeapon && !item.Type.IsArmor && !item.Type.IsAccessory) {
+        if (!item.Type.IsWeapon && item.Type is { IsArmor: false, IsAccessory: false, IsPet: false }) {
             return ChangeAttributesScrollError.s_itemremake_scroll_error_impossible_slot;
         }
         if (item.Metadata.Limit.Level < Constant.ChangeAttributesMinLevel) {
@@ -188,14 +234,18 @@ public class ChangeAttributesScrollHandler : PacketHandler<GameSession> {
         if (!int.TryParse(scroll.Metadata.Function?.Parameters, out int remakeId)) {
             return ChangeAttributesScrollError.s_itemremake_scroll_error_invalid_scroll_data;
         }
-        if (!TableMetadata.ItemRemakeScrollTable.Entries.TryGetValue(remakeId, out ItemRemakeScrollMetadata? metadata)) {
+        if (!TableMetadata.ItemRemakeScrollTable.Entries.TryGetValue(remakeId, out metadata)) {
             return ChangeAttributesScrollError.s_itemremake_scroll_error_invalid_scroll_data;
         }
 
         if (item.Metadata.Limit.Level < metadata.MinLevel || item.Metadata.Limit.Level > metadata.MaxLevel) {
             return ChangeAttributesScrollError.s_itemremake_scroll_error_impossible_item;
         }
-        if (!metadata.Rarities.Contains(item.Rarity) || !metadata.ItemTypes.Contains(item.Type.Type)) {
+        if (!metadata.Rarities.Contains(item.Rarity) || !metadata.ItemTypes.Contains(item.Type.Type) && !metadata.OnlyPet) {
+            return ChangeAttributesScrollError.s_itemremake_scroll_error_impossible_item;
+        }
+
+        if (metadata.OnlyPet && !item.Type.IsPet) {
             return ChangeAttributesScrollError.s_itemremake_scroll_error_impossible_item;
         }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for new scroll attributes, including roll attribute, roll value type, and pet-only scrolls when modifying item attributes.
  - Scrolls can now be applied to both gear and pet items, expanding compatibility.

- **Bug Fixes**
  - Improved error handling when applying scrolls and consuming items, with rollback if any step fails.

- **Refactor**
  - Enhanced attribute randomization logic to distinguish between scroll types and improve compatibility checks.
  - Updated item retrieval logic to streamline gear and pet item handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->