### PR TITLE
Fix: homes invalid expiry time

### DIFF
--- a/Maple2.Database/Storage/Game/GameStorage.Map.cs
+++ b/Maple2.Database/Storage/Game/GameStorage.Map.cs
@@ -213,14 +213,8 @@ public partial class GameStorage {
                 return null;
             }
 
-            if (!string.IsNullOrEmpty(ugcMap.Name) && ugcMap.MapId is Constant.DefaultHomeMapId && ugcMap.ExpiryTime != Home.HomeExpiryTime) {
-                Logger.LogError("Plot {Id} for {OwnerId} is initialized but it's ExpiryTime is not set to Home.HomeExpiryTime. Why?", ugcMap.Id, ugcMap.OwnerId);
-
-                ugcMap.ExpiryTime = Home.HomeExpiryTime;
-                Context.UgcMap.Update(ugcMap);
-                if (!Context.TrySaveChanges()) {
-                    return null;
-                }
+            if (!ValidateAndFixHomeExpiryTime(ugcMap)) {
+                return null;
             }
 
             var plot = new Plot(group) {
@@ -259,14 +253,8 @@ public partial class GameStorage {
                 return null;
             }
 
-            if (!string.IsNullOrEmpty(ugcMap.Name) && ugcMap.MapId is Constant.DefaultHomeMapId && ugcMap.ExpiryTime != Home.HomeExpiryTime) {
-                Logger.LogError("Plot {Id} for {OwnerId} is initialized but it's ExpiryTime is not set to Home.HomeExpiryTime. Why?", ugcMap.Id, ugcMap.OwnerId);
-
-                ugcMap.ExpiryTime = Home.HomeExpiryTime;
-                Context.UgcMap.Update(ugcMap);
-                if (!Context.TrySaveChanges()) {
-                    return null;
-                }
+            if (!ValidateAndFixHomeExpiryTime(ugcMap)) {
+                return null;
             }
 
             return new PlotInfo(group) {
@@ -333,6 +321,17 @@ public partial class GameStorage {
                 Interact = ToInteractCube(model.Interact),
                 Type = PlotCube.CubeType.Construction,
             };
+        }
+
+        private bool ValidateAndFixHomeExpiryTime(UgcMap ugcMap) {
+            if (!string.IsNullOrEmpty(ugcMap.Name) && ugcMap.MapId is Constant.DefaultHomeMapId && ugcMap.ExpiryTime != Home.HomeExpiryTime) {
+                Logger.LogError("Plot {Id} for {OwnerId} is initialized but it's ExpiryTime is not set to Home.HomeExpiryTime. Why?", ugcMap.Id, ugcMap.OwnerId);
+
+                ugcMap.ExpiryTime = Home.HomeExpiryTime;
+                Context.UgcMap.Update(ugcMap);
+                return Context.TrySaveChanges();
+            }
+            return true;
         }
     }
 }

--- a/Maple2.Database/Storage/Game/GameStorage.Map.cs
+++ b/Maple2.Database/Storage/Game/GameStorage.Map.cs
@@ -5,6 +5,7 @@ using Maple2.Model.Common;
 using Maple2.Model.Game;
 using Maple2.Model.Metadata;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using Z.EntityFramework.Plus;
 using Home = Maple2.Model.Game.Home;
 using InteractCube = Maple2.Model.Game.InteractCube;
@@ -212,6 +213,16 @@ public partial class GameStorage {
                 return null;
             }
 
+            if (!string.IsNullOrEmpty(ugcMap.Name) && ugcMap.MapId is Constant.DefaultHomeMapId && ugcMap.ExpiryTime != Home.HomeExpiryTime) {
+                Logger.LogError("Plot {Id} for {OwnerId} is initialized but it's ExpiryTime is not set to Home.HomeExpiryTime. Why?", ugcMap.Id, ugcMap.OwnerId);
+
+                ugcMap.ExpiryTime = Home.HomeExpiryTime;
+                Context.UgcMap.Update(ugcMap);
+                if (!Context.TrySaveChanges()) {
+                    return null;
+                }
+            }
+
             var plot = new Plot(group) {
                 Id = ugcMap.Id,
                 OwnerId = ugcMap.OwnerId,
@@ -246,6 +257,16 @@ public partial class GameStorage {
 
             if (!metadata.Plots.TryGetValue(ugcMap.Number, out UgcMapGroup? group)) {
                 return null;
+            }
+
+            if (!string.IsNullOrEmpty(ugcMap.Name) && ugcMap.MapId is Constant.DefaultHomeMapId && ugcMap.ExpiryTime != Home.HomeExpiryTime) {
+                Logger.LogError("Plot {Id} for {OwnerId} is initialized but it's ExpiryTime is not set to Home.HomeExpiryTime. Why?", ugcMap.Id, ugcMap.OwnerId);
+
+                ugcMap.ExpiryTime = Home.HomeExpiryTime;
+                Context.UgcMap.Update(ugcMap);
+                if (!Context.TrySaveChanges()) {
+                    return null;
+                }
             }
 
             return new PlotInfo(group) {

--- a/Maple2.Model/Game/User/Home.cs
+++ b/Maple2.Model/Game/User/Home.cs
@@ -59,6 +59,8 @@ public class Home : IByteSerializable {
 
     public bool IsHomeSetup => !string.IsNullOrEmpty(Name);
 
+    public static DateTimeOffset HomeExpiryTime = new DateTimeOffset(2900, 12, 31, 0, 0, 0, TimeSpan.Zero);
+
     public Home() {
         message = string.Empty;
         Permissions = new Dictionary<HomePermission, HomePermissionSetting>();
@@ -69,7 +71,7 @@ public class Home : IByteSerializable {
 
     public void NewHomeDefaults(string characterName) {
         Indoor.Name = characterName;
-        Indoor.ExpiryTime = new DateTimeOffset(2900, 12, 31, 0, 0, 0, TimeSpan.Zero).ToUnixTimeSeconds();
+        Indoor.ExpiryTime = HomeExpiryTime.ToUnixTimeSeconds();
         Message = "Thanks for visiting. Come back soon!";
         DecorationLevel = 1;
         Passcode = string.Empty;

--- a/Maple2.Server.Game/PacketHandlers/QuitHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/QuitHandler.cs
@@ -24,7 +24,9 @@ public class QuitHandler : PacketHandler<GameSession> {
         bool quitGame = packet.ReadBool();
 
         // Reset map to return map
-        session.Player.Value.Character.MapId = session.Player.Value.Character.ReturnMapId;
+        if (session.Player.Value.Character.ReturnMapId is not 0) {
+            session.Player.Value.Character.MapId = session.Player.Value.Character.ReturnMapId;
+        }
 
         // Fully close client
         if (quitGame) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected expiry time handling for default home maps to ensure consistency and prevent invalid expiry values.
	- Prevented character map location from being reset to an invalid state when quitting if no valid return map is set.

- **New Features**
	- Added a new static expiry time setting for home maps, ensuring a consistent default expiry date across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->