### PR TITLE
Small fixes

### DIFF
--- a/Maple2.File.Ingest/Mapper/ItemMapper.cs
+++ b/Maple2.File.Ingest/Mapper/ItemMapper.cs
@@ -69,7 +69,7 @@ public class ItemMapper : TypeMapper<ItemMetadata> {
                     _ => 0
                 };
             } else if (data.life.usePeriod > 0) {
-                expirationDuration = data.life.usePeriod;
+                expirationDuration = (long) TimeSpan.FromMinutes(data.life.usePeriod).TotalSeconds;
             }
 
             var hairList = new List<DefaultHairMetadata>();

--- a/Maple2.Server.Game/Manager/FishingManager.cs
+++ b/Maple2.Server.Game/Manager/FishingManager.cs
@@ -337,6 +337,10 @@ public class FishingManager {
         }
         session.ConditionUpdate(ConditionType.fish, codeLong: selectedFish.Id, targetLong: session.Field.MapId);
 
+        if (masteryExp == 0) {
+            return;
+        }
+
         session.Mastery[MasteryType.Fishing] += masteryExp;
         short masteryLevel = session.Mastery.GetLevel(MasteryType.Fishing);
         session.Send(FishingPacket.IncreaseMastery(selectedFish.Id, masteryLevel, masteryExp, caughtFishType));

--- a/Maple2.Server.Game/Packets/ItemUsePacket.cs
+++ b/Maple2.Server.Game/Packets/ItemUsePacket.cs
@@ -11,6 +11,7 @@ public static class ItemUsePacket {
         CharacterSlotAdded = 2,
         MaxCharacterSlots = 3,
         QuestScroll = 4,
+        FashionCoupon = 5, // Codi/outfit fashion tab on player
         BeautyCoupon = 6,
     }
 


### PR DESCRIPTION
- Fixed expiration on time limited items. Now treats the expiration period as minutes instead of seconds
- Fixed no longer sending mastery increase notification on fishing if the amount is 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected expiration duration calculation to use seconds instead of an unspecified raw value.
	- Prevented fishing mastery updates and notifications when no mastery experience is gained.

- **New Features**
	- Added support for a new "Fashion Coupon" command related to the outfit fashion tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->