### PR TITLE
fix(quest): filter quests by condition type before updating

### DIFF
--- a/Maple2.Server.Game/Manager/QuestManager.cs
+++ b/Maple2.Server.Game/Manager/QuestManager.cs
@@ -185,11 +185,12 @@ public sealed class QuestManager {
     /// <param name="codeLong">condition code parameter in long.</param>
     public void Update(ConditionType type, long counter = 1, string targetString = "", long targetLong = 0, string codeString = "", long codeLong = 0) {
         IEnumerable<Quest> quests = characterValues.Values.Where(quest => quest.State != QuestState.Completed)
-            .Concat(accountValues.Values.Where(quest => quest.State != QuestState.Completed));
+            .Concat(accountValues.Values.Where(quest => quest.State != QuestState.Completed))
+            .Where(x => x.Conditions.Values.Any(quest => quest.Metadata.Type == type));
         foreach (Quest quest in quests) {
             // TODO: Not sure if ProgressMap really means that only progress counts in this map. It doesn't make sense for some quests.
             // Testing only on FieldMission for now.
-            if (quest.Metadata.Basic is { Type: QuestType.FieldMission, ProgressMaps: not null }) {
+            if (quest.Metadata.Basic is { Type: QuestType.FieldMission, ProgressMaps: not null } && session.Field is not null) {
                 switch (session.Field.Metadata.Property.ExploreType) {
                     case 1 when !quest.Metadata.Basic.ProgressMaps.Contains(session.Player.Value.Character.MapId):
                     case 2 when !quest.Metadata.Basic.ProgressMaps.Any(x => session.Player.Value.Character.ReturnMaps.Contains(x)):


### PR DESCRIPTION
Filter quests to update only those with conditions matching the given
type, improving performance by avoiding unnecessary updates. 
Add a null check for session.Field before accessing its properties to prevent
potential null reference errors during quest progress evaluation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved quest update reliability by adding checks to prevent errors when certain quest or session data is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->