### PR TITLE
fix(collision): cast point coordinates to int in Contains method

### DIFF
--- a/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.cs
+++ b/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.cs
@@ -323,7 +323,7 @@ public partial class FieldManager : IField {
     }
 
     public void EnsurePlayerPosition(FieldPlayer player) {
-        if (Entities.BoundingBox.Contains(player.Position)) {
+        if (Entities.BoundingBox.Contains(player.Position, 0.001f)) {
             return;
         }
 

--- a/Maple2.Server.Tests/Tools/Collision/TrapezoidTests.cs
+++ b/Maple2.Server.Tests/Tools/Collision/TrapezoidTests.cs
@@ -45,9 +45,11 @@ public class TrapezoidTests {
 
         var insidePoint = new Vector2(1.5f, 1.5f);
         Assert.That(trapezoid.Contains(insidePoint), Is.True);
-        var edgePoint = new Vector2(2, 2);
-        Assert.That(trapezoid.Contains(edgePoint), Is.False);
-        var outsidePoint = new Vector2(2, 2);
-        Assert.That(trapezoid.Contains(outsidePoint), Is.False);
+
+        var onEdgePoint = new Vector2(2, 2);
+        Assert.That(trapezoid.Contains(onEdgePoint), Is.False, "Point on edge should be considered outside");
+
+        var outsidePoint = new Vector2(5, 5);
+        Assert.That(trapezoid.Contains(outsidePoint), Is.False, "Point clearly outside should be considered outside");
     }
 }

--- a/Maple2.Tools/Collision/BoundingBox.cs
+++ b/Maple2.Tools/Collision/BoundingBox.cs
@@ -22,11 +22,8 @@ public class BoundingBox : Polygon {
         ]);
     }
 
-    public override bool Contains(in Vector2 point) {
-        // Truncate to integer coordinates for pixel-perfect collision detection
-        int pointX = (int) point.X;
-        int pointY = (int) point.Y;
-        return min.X <= pointX && pointX <= max.X && min.Y <= pointY && pointY <= max.Y;
+    public override bool Contains(in Vector2 point, float epsilon = 1e-5f) {
+        return min.X - epsilon <= point.X && point.X <= max.X + epsilon && min.Y - epsilon <= point.Y && point.Y <= max.Y + epsilon;
     }
 
     public override string ToString() {

--- a/Maple2.Tools/Collision/BoundingBox.cs
+++ b/Maple2.Tools/Collision/BoundingBox.cs
@@ -23,6 +23,7 @@ public class BoundingBox : Polygon {
     }
 
     public override bool Contains(in Vector2 point) {
+        // Truncate to integer coordinates for pixel-perfect collision detection
         int pointX = (int) point.X;
         int pointY = (int) point.Y;
         return min.X <= pointX && pointX <= max.X && min.Y <= pointY && pointY <= max.Y;

--- a/Maple2.Tools/Collision/BoundingBox.cs
+++ b/Maple2.Tools/Collision/BoundingBox.cs
@@ -23,7 +23,9 @@ public class BoundingBox : Polygon {
     }
 
     public override bool Contains(in Vector2 point) {
-        return min.X <= point.X && point.X <= max.X && min.Y <= point.Y && point.Y <= max.Y;
+        int pointX = (int) point.X;
+        int pointY = (int) point.Y;
+        return min.X <= pointX && pointX <= max.X && min.Y <= pointY && pointY <= max.Y;
     }
 
     public override string ToString() {

--- a/Maple2.Tools/Collision/Circle.cs
+++ b/Maple2.Tools/Collision/Circle.cs
@@ -12,7 +12,7 @@ public class Circle : IPolygon {
         Radius = radius;
     }
 
-    public virtual bool Contains(in Vector2 point) {
+    public virtual bool Contains(in Vector2 point, float epsilon = 1e-5f) {
         return Vector2.DistanceSquared(Origin, point) <= Radius * Radius;
     }
 

--- a/Maple2.Tools/Collision/Circle.cs
+++ b/Maple2.Tools/Collision/Circle.cs
@@ -13,7 +13,8 @@ public class Circle : IPolygon {
     }
 
     public virtual bool Contains(in Vector2 point, float epsilon = 1e-5f) {
-        return Vector2.DistanceSquared(Origin, point) <= Radius * Radius;
+        float expandedRadius = Radius + epsilon;
+        return Vector2.DistanceSquared(Origin, point) <= expandedRadius * expandedRadius;
     }
 
     public Vector2[] GetAxes(Polygon? other) {

--- a/Maple2.Tools/Collision/HoleCircle.cs
+++ b/Maple2.Tools/Collision/HoleCircle.cs
@@ -10,8 +10,8 @@ public sealed class HoleCircle : Circle {
         hole = new Circle(origin, innerRadius);
     }
 
-    public override bool Contains(in Vector2 point) {
-        return base.Contains(point) && !hole.Contains(point);
+    public override bool Contains(in Vector2 point, float epsilon = 1e-5f) {
+        return base.Contains(point, epsilon) && !hole.Contains(point);
     }
 
     // Inherited GetAxes() and AxisProjection() includes hole, but is unused.

--- a/Maple2.Tools/Collision/HoleCircle.cs
+++ b/Maple2.Tools/Collision/HoleCircle.cs
@@ -11,7 +11,7 @@ public sealed class HoleCircle : Circle {
     }
 
     public override bool Contains(in Vector2 point, float epsilon = 1e-5f) {
-        return base.Contains(point, epsilon) && !hole.Contains(point);
+        return base.Contains(point, epsilon) && !hole.Contains(point, epsilon);
     }
 
     // Inherited GetAxes() and AxisProjection() includes hole, but is unused.

--- a/Maple2.Tools/Collision/IPolygon.cs
+++ b/Maple2.Tools/Collision/IPolygon.cs
@@ -6,7 +6,7 @@ namespace Maple2.Tools.Collision;
 public interface IPolygon {
     public static readonly IPolygon Null = new NullPolygon();
 
-    public bool Contains(float x, float y) => Contains(new Vector2(x, y), 0.001f);
+    public bool Contains(float x, float y, float epsilon = 0.001f) => Contains(new Vector2(x, y), epsilon);
 
     public bool Contains(in Vector2 point, float epsilon = 1e-5f);
 

--- a/Maple2.Tools/Collision/IPolygon.cs
+++ b/Maple2.Tools/Collision/IPolygon.cs
@@ -6,9 +6,9 @@ namespace Maple2.Tools.Collision;
 public interface IPolygon {
     public static readonly IPolygon Null = new NullPolygon();
 
-    public bool Contains(float x, float y) => Contains(new Vector2(x, y));
+    public bool Contains(float x, float y) => Contains(new Vector2(x, y), 0.001f);
 
-    public bool Contains(in Vector2 point);
+    public bool Contains(in Vector2 point, float epsilon = 1e-5f);
 
     public Vector2[] GetAxes(Polygon? other);
 
@@ -18,6 +18,6 @@ public interface IPolygon {
 
     private class NullPolygon : Polygon {
         public override Vector2[] Points => [];
-        public override bool Contains(in Vector2 point) => false;
+        public override bool Contains(in Vector2 point, float epsilon = 1e-5f) => false;
     }
 }

--- a/Maple2.Tools/Collision/IPrism.cs
+++ b/Maple2.Tools/Collision/IPrism.cs
@@ -6,7 +6,7 @@ public interface IPrism {
     public IPolygon Polygon { get; }
     public Range Height { get; }
 
-    public bool Contains(in Vector3 point);
+    public bool Contains(in Vector3 point, float epsilon = 1e-5f);
 
     public bool Intersects(IPrism prism);
 }

--- a/Maple2.Tools/Collision/PointPrism.cs
+++ b/Maple2.Tools/Collision/PointPrism.cs
@@ -26,7 +26,7 @@ public readonly struct PointPrism : IPrism {
     }
 
     private readonly struct Point(float x, float y) : IPolygon {
-        public bool Contains(in Vector2 point) {
+        public bool Contains(in Vector2 point, float epsilon = 1e-5f) {
             const float tolerance = 0.0000001f;
             return Math.Abs(x - point.X) < tolerance && Math.Abs(y - point.Y) < tolerance;
         }

--- a/Maple2.Tools/Collision/PointPrism.cs
+++ b/Maple2.Tools/Collision/PointPrism.cs
@@ -17,8 +17,10 @@ public readonly struct PointPrism : IPrism {
         Height = new Range(origin.Z, origin.Z);
     }
 
-    public bool Contains(in Vector3 other) {
-        return origin == other;
+    public bool Contains(in Vector3 other, float epsilon = 1e-5f) {
+        return Math.Abs(origin.X - other.X) < epsilon &&
+               Math.Abs(origin.Y - other.Y) < epsilon &&
+               Math.Abs(origin.Z - other.Z) < epsilon;
     }
 
     public bool Intersects(IPrism prism) {

--- a/Maple2.Tools/Collision/PointPrism.cs
+++ b/Maple2.Tools/Collision/PointPrism.cs
@@ -26,10 +26,7 @@ public readonly struct PointPrism : IPrism {
     }
 
     private readonly struct Point(float x, float y) : IPolygon {
-        public bool Contains(in Vector2 point, float epsilon = 1e-5f) {
-            const float tolerance = 0.0000001f;
-            return Math.Abs(x - point.X) < tolerance && Math.Abs(y - point.Y) < tolerance;
-        }
+        public bool Contains(in Vector2 point, float epsilon = 1e-5f) => Math.Abs(x - point.X) < epsilon && Math.Abs(y - point.Y) < epsilon;
 
         public bool Intersects(IPolygon polygon) {
             return polygon.Contains(x, y);

--- a/Maple2.Tools/Collision/Polygon.cs
+++ b/Maple2.Tools/Collision/Polygon.cs
@@ -19,7 +19,7 @@ public abstract class Polygon : IPolygon {
 
         for (int i = 0; i < Points.Length; i++) {
             // If point is in the polygon
-            if (Points[i] == point) {
+            if (Vector2.DistanceSquared(Points[i], point) <= epsilon * epsilon) {
                 return true;
             }
 

--- a/Maple2.Tools/Collision/Polygon.cs
+++ b/Maple2.Tools/Collision/Polygon.cs
@@ -18,16 +18,11 @@ public abstract class Polygon : IPolygon {
         int neg = 0;
 
         for (int i = 0; i < Points.Length; i++) {
-            // If point is in the polygon
-            if (Vector2.DistanceSquared(Points[i], point) <= epsilon * epsilon) {
-                return true;
-            }
-
             // Form a segment between the i'th point
             float x1 = Points[i].X;
             float y1 = Points[i].Y;
 
-            // And the i+1'th, or if i is the last, with the first point
+            // And the i+1'th, or if it is the last, with the first point
             int i2 = (i + 1) % Points.Length;
 
             float x = point.X;
@@ -38,13 +33,11 @@ public abstract class Polygon : IPolygon {
 
             // Compute the cross product
             float d = (x - x1) * (y2 - y1) - (y - y1) * (x2 - x1);
-            switch (d) {
-                case > 0:
-                    pos++;
-                    break;
-                case < 0:
-                    neg++;
-                    break;
+
+            if (d > epsilon) {
+                pos++;
+            } else if (d < -epsilon) {
+                neg++;
             }
 
             // If the sign changes, then point is outside

--- a/Maple2.Tools/Collision/Polygon.cs
+++ b/Maple2.Tools/Collision/Polygon.cs
@@ -9,7 +9,7 @@ namespace Maple2.Tools.Collision;
 public abstract class Polygon : IPolygon {
     public abstract Vector2[] Points { get; }
 
-    public virtual bool Contains(in Vector2 point) {
+    public virtual bool Contains(in Vector2 point, float epsilon = 1e-5f) {
         // Check if a triangle or higher n-gon
         Debug.Assert(Points.Length >= 3);
 

--- a/Maple2.Tools/Collision/Prism.cs
+++ b/Maple2.Tools/Collision/Prism.cs
@@ -11,8 +11,8 @@ public readonly struct Prism : IPrism {
         Height = new Range(baseHeight, baseHeight + height);
     }
 
-    public bool Contains(in Vector3 point) {
-        return Height.Min <= point.Z && point.Z <= Height.Max && Polygon.Contains(point.X, point.Y);
+    public bool Contains(in Vector3 point, float epsilon = 1e-5f) {
+        return Height.Min <= point.Z && point.Z <= Height.Max && Polygon.Contains(point.X, point.Y, epsilon);
     }
 
     public bool Intersects(IPrism prism) {


### PR DESCRIPTION

- Fix: #506

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Introduced a tolerance margin for point containment checks across various shapes, improving accuracy near edges and boundaries.
- **Tests**
	- Improved clarity and correctness of point containment test cases for trapezoids.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->