### PR TITLE
Add retry logic for AddChannel gRPC call

### DIFF
--- a/Maple2.Server.Game/Program.cs
+++ b/Maple2.Server.Game/Program.cs
@@ -54,10 +54,10 @@ const int maxRetries = 3;
 const int delayMs = 5000;
 int attempt = 0;
 
+GrpcChannel channel = GrpcChannel.ForAddress(Target.GrpcWorldUri);
+var worldClient = new WorldClient(channel);
 while (attempt < maxRetries) {
     try {
-        GrpcChannel channel = GrpcChannel.ForAddress(Target.GrpcWorldUri);
-        var worldClient = new WorldClient(channel);
         response = worldClient.AddChannel(new AddChannelRequest {
             GameIp = Target.GameIp.ToString(),
             GrpcGameIp = Target.GrpcGameIp,

--- a/Maple2.Server.Game/Program.cs
+++ b/Maple2.Server.Game/Program.cs
@@ -74,7 +74,7 @@ while (attempt < maxRetries) {
 }
 
 if (response == null || response.GamePort == 0) {
-    Log.Error("Failed to add channel to World Server after {MaxRetries} attempts.", maxRetries);
+    Log.Error("Failed to add channel to World Server. Is the World Server running?");
     return;
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when connecting to the World Server by retrying up to three times in case of connection failures, with clearer error messages if the connection cannot be established.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->