### PR TITLE
fix: Plot expiring

### DIFF
--- a/Maple2.Database/Storage/Game/GameStorage.Item.cs
+++ b/Maple2.Database/Storage/Game/GameStorage.Item.cs
@@ -2,6 +2,7 @@
 using Maple2.Database.Model;
 using Maple2.Model.Enum;
 using Maple2.Model.Metadata;
+using Microsoft.EntityFrameworkCore;
 using Item = Maple2.Model.Game.Item;
 using PetConfig = Maple2.Model.Game.PetConfig;
 using UgcItemLook = Maple2.Model.Game.UgcItemLook;
@@ -65,8 +66,20 @@ public partial class GameStorage {
 
             return ugcModel.Template;
         }
+
         public IDictionary<ItemGroup, List<Item>> GetItemGroups(long ownerId, params ItemGroup[] groups) {
             return Context.Item.Where(item => item.OwnerId == ownerId && groups.Contains(item.Group))
+                .AsEnumerable()
+                .GroupBy(item => item.Group)
+                .ToDictionary(
+                    group => group.Key,
+                    group => group.Select(ToItem).Where(item => item != null).ToList()
+                )!;
+        }
+
+        public IDictionary<ItemGroup, List<Item>> GetItemGroupsNoTracking(long ownerId, params ItemGroup[] groups) {
+            return Context.Item.Where(item => item.OwnerId == ownerId && groups.Contains(item.Group))
+                .AsNoTracking()
                 .AsEnumerable()
                 .GroupBy(item => item.Group)
                 .ToDictionary(

--- a/Maple2.Model/Metadata/Constants.cs
+++ b/Maple2.Model/Metadata/Constants.cs
@@ -30,7 +30,7 @@ public static class Constant {
     public const byte MaxHomeArea = 25;
     public const byte MinHomeHeight = 3;
     public const byte MaxHomeHeight = 15;
-    public const short FurnishingStorageMaxSlot = 512;
+    public const short FurnishingStorageMaxSlot = 1024;
     public const int ConstructionCubeItemId = 50200183;
     public const int HomeNameMaxLength = 16;
     public const int HomeMessageMaxLength = 100;

--- a/Maple2.Server.Game/Manager/Items/FurnishingManager.cs
+++ b/Maple2.Server.Game/Manager/Items/FurnishingManager.cs
@@ -238,6 +238,10 @@ public class FurnishingManager {
         lock (session.Item) {
             Item? stored = storage.FirstOrDefault(existing => existing.Id == item.Id && existing.Template?.Url == template?.Url);
             if (stored == null) {
+                if (storage.OpenSlots <= 0) {
+                    logger.Error("Furnishing storage is full, cannot add item: {ItemId}", item.Id);
+                    return 0;
+                }
                 item.Group = ItemGroup.Furnishing;
                 using GameStorage.Request db = session.GameStorage.Context();
                 Item? newItem = db.CreateItem(session.AccountId, item);

--- a/Maple2.Server.World/WorldServer.cs
+++ b/Maple2.Server.World/WorldServer.cs
@@ -308,7 +308,7 @@ public class WorldServer {
             return;
         }
 
-        List<Item>? items = db.GetItemGroups(plot.OwnerId, ItemGroup.Furnishing).GetValueOrDefault(ItemGroup.Furnishing);
+        List<Item>? items = db.GetItemGroupsNoTracking(plot.OwnerId, ItemGroup.Furnishing).GetValueOrDefault(ItemGroup.Furnishing);
         if (items == null) {
             logger.Warning("No furnishing items found for owner id {OwnerId}", outdoorPlot.OwnerId);
             return;


### PR DESCRIPTION
Fix EF tracking when adding items from plots expiring
Fix MapDataParser not producing the same output 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an option for retrieving item groups with improved performance for read-only operations.

* **Refactor**
  * Streamlined map data processing logic for improved clarity and maintainability.
  * Map data results are now consistently ordered before being returned.
  * Enhanced item layout application to continue processing despite placement failures and improved player repositioning behavior.

* **Bug Fixes**
  * Prevented adding items when storage slots are full to avoid errors.
  * Improved metadata retrieval and error logging for housing items.

* **Chores**
  * Updated internal data retrieval in plot management to use the new performance-optimized method.
  * Increased furnishing storage capacity from 512 to 1024 slots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->