### PR TITLE
Fix: Forfeiting plot from another map

### DIFF
--- a/Maple2.Server.Game/Manager/HousingManager.cs
+++ b/Maple2.Server.Game/Manager/HousingManager.cs
@@ -230,7 +230,7 @@ public class HousingManager {
             return null;
         }
 
-        if ( !fieldManager.Plots.TryGetValue(plotInfo.Number, out Plot? plot)) {
+        if (!fieldManager.Plots.TryGetValue(plotInfo.Number, out Plot? plot)) {
             session.Send(CubePacket.Error(UgcMapError.s_ugcmap_system_error));
             return null;
         }

--- a/Maple2.Server.Game/Session/GameSession.cs
+++ b/Maple2.Server.Game/Session/GameSession.cs
@@ -128,8 +128,8 @@ public sealed partial class GameSession : Core.Network.Session {
     }
 
     public bool FindField(int mapId, [NotNullWhen(true)] out FieldManager? field) {
-         field = server.GetField(mapId);
-         return field is not null;
+        field = server.GetField(mapId);
+        return field is not null;
     }
 
     public bool EnterServer(long accountId, Guid machineId, MigrateInResponse migrateResponse) {

--- a/Maple2.Server.Game/Session/GameSession.cs
+++ b/Maple2.Server.Game/Session/GameSession.cs
@@ -127,6 +127,11 @@ public sealed partial class GameSession : Core.Network.Session {
         return server.GetSession(characterId, out other);
     }
 
+    public bool FindField(int mapId, [NotNullWhen(true)] out FieldManager? field) {
+         field = server.GetField(mapId);
+         return field is not null;
+    }
+
     public bool EnterServer(long accountId, Guid machineId, MigrateInResponse migrateResponse) {
         long characterId = migrateResponse.CharacterId;
         int channel = migrateResponse.Channel;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when forfeiting housing plots by ensuring the correct field context is used, reducing potential errors during the forfeit process.

* **New Features**
  * Added a method to enhance field lookup capabilities within the game session.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->