### PR TITLE
fix(badges): move unknown equip slot check inside Gear and Outfit cases to avoid premature deletion

### DIFF
--- a/Maple2.Server.Game/Manager/Items/EquipManager.cs
+++ b/Maple2.Server.Game/Manager/Items/EquipManager.cs
@@ -29,16 +29,20 @@ public class EquipManager {
         foreach ((ItemGroup tab, List<Item> items) in db.GetItemGroups(session.CharacterId, ItemGroup.Gear, ItemGroup.Outfit, ItemGroup.Badge)) {
             foreach (Item item in items) {
                 EquipSlot equipSlot = item.EquipSlot();
-                if (equipSlot is EquipSlot.Unknown) {
-                    delete.Add(item);
-                    continue;
-                }
 
                 switch (tab) {
                     case ItemGroup.Gear:
+                        if (equipSlot is EquipSlot.Unknown) {
+                            delete.Add(item);
+                            continue;
+                        }
                         Gear[equipSlot] = item;
                         break;
                     case ItemGroup.Outfit:
+                        if (equipSlot is EquipSlot.Unknown) {
+                            delete.Add(item);
+                            continue;
+                        }
                         Outfit[equipSlot] = item;
                         break;
                     case ItemGroup.Badge:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved item handling so that only Gear and Outfit items with unknown equip slots are now skipped during loading, ensuring other item groups are processed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->