### PR TITLE
Add insignia and title commands

### DIFF
--- a/Maple2.Server.Game/Commands/InsigniaCommand.cs
+++ b/Maple2.Server.Game/Commands/InsigniaCommand.cs
@@ -1,0 +1,45 @@
+﻿using System.CommandLine;
+using System.CommandLine.Invocation;
+using Maple2.Model.Enum;
+using Maple2.Model.Metadata;
+using Maple2.Server.Game.Packets;
+using Maple2.Server.Game.Session;
+
+namespace Maple2.Server.Game.Commands;
+
+public class InsigniaCommand : GameCommand {
+    private readonly GameSession session;
+
+    public InsigniaCommand(GameSession session) : base(AdminPermissions.GameMaster, "insignia", "Set the player's insignia") {
+        this.session = session;
+        var insigniaId = new Argument<short>("insigniaId", "The ID of the insignia to set");
+        AddArgument(insigniaId);
+
+        this.SetHandler<InvocationContext, short>(Handle, insigniaId);
+    }
+
+    private void Handle(InvocationContext context, short insigniaId) {
+        if (session.Field == null) return;
+
+        if (!session.TableMetadata.InsigniaTable.Entries.TryGetValue(insigniaId, out InsigniaTable.Entry? insigniaMetadata)) {
+            context.Console.WriteLine($"Insignia ID {insigniaId} does not exist.");
+            context.Console.WriteLine($"Available insignias: {string.Join(", ", session.TableMetadata.InsigniaTable.Entries.Keys)}");
+            return;
+        }
+
+        // Check and remove any existing insignia buffs
+        if (session.TableMetadata.InsigniaTable.Entries.TryGetValue(session.Player.Value.Character.Insignia, out InsigniaTable.Entry? oldInsigniaMetadata) && oldInsigniaMetadata.BuffId > 0) {
+            session.Player.Buffs.Remove(oldInsigniaMetadata.BuffId, session.Player.ObjectId);
+        }
+
+        session.Player.Value.Character.Insignia = insigniaId;
+
+        // Apply the new insignia buff if applicable
+        if (insigniaMetadata.BuffId > 0) {
+            session.Player.Buffs.AddBuff(session.Player, session.Player, insigniaMetadata.BuffId, insigniaMetadata.BuffLevel, session.Field.FieldTick);
+        }
+
+        session.Field.Broadcast(InsigniaPacket.Update(session.Player.ObjectId, insigniaId, true));
+        context.Console.WriteLine($"Insignia set to ID {insigniaId}.");
+    }
+}

--- a/Maple2.Server.Game/Commands/TitleCommand.cs
+++ b/Maple2.Server.Game/Commands/TitleCommand.cs
@@ -1,0 +1,29 @@
+﻿using System.CommandLine;
+using System.CommandLine.Invocation;
+using Maple2.Model.Enum;
+using Maple2.Server.Game.Packets;
+using Maple2.Server.Game.Session;
+
+namespace Maple2.Server.Game.Commands;
+
+public class TitleCommand : GameCommand {
+    private readonly GameSession session;
+    public TitleCommand(GameSession session) : base(AdminPermissions.GameMaster, "title", "Gain the title") {
+        this.session = session;
+
+        var titleId = new Argument<int>("titleId", "The ID of the title to gain");
+        AddArgument(titleId);
+        this.SetHandler<InvocationContext, int>(Handle, titleId);
+    }
+
+    private void Handle(InvocationContext context, int titleId) {
+        if (session.Field == null) return;
+
+        if (!session.Player.Value.Unlock.Titles.Add(titleId)) {
+            context.Console.WriteLine($"You already have the title {titleId}.");
+            return;
+        }
+
+        session.Send(UserEnvPacket.AddTitle(titleId));
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command for game masters to set a player's insignia by specifying an insignia ID.
  * Added a command for game masters to grant a title to a player by specifying a title ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->