### PR TITLE
Fix: npc animations

### DIFF
--- a/Maple2.Server.Game/Model/Field/Actor/ActorStateComponent/MovementStateStates/MovementState.Emote.cs
+++ b/Maple2.Server.Game/Model/Field/Actor/ActorStateComponent/MovementStateStates/MovementState.Emote.cs
@@ -4,6 +4,7 @@ namespace Maple2.Server.Game.Model.ActorStateComponent;
 
 public partial class MovementState {
     private long emoteLimitTick;
+    private bool dontIdleOnStateEnd;
 
     private void EmoteStateUpdate(long tickCount, long tickDelta) {
         if (tickCount >= emoteLimitTick && emoteLimitTick != 0) {
@@ -22,6 +23,10 @@ public partial class MovementState {
                 }
 
                 emoteActionTask?.Completed();
+
+                if (dontIdleOnStateEnd) {
+                    return;
+                }
 
                 Idle();
 

--- a/Maple2.Server.Game/Model/Field/Actor/ActorStateComponent/MovementStateTasks/MovementState.StandbyTask.cs
+++ b/Maple2.Server.Game/Model/Field/Actor/ActorStateComponent/MovementStateTasks/MovementState.StandbyTask.cs
@@ -25,6 +25,7 @@ public partial class MovementState {
 
     private void Standby(NpcTask task, IActor? target, bool isIdle, string sequence) {
         Idle(sequence);
+        dontIdleOnStateEnd = isIdle;
 
         if (target is null) {
             return;

--- a/Maple2.Server.Game/Model/Field/Actor/FieldNpc.cs
+++ b/Maple2.Server.Game/Model/Field/Actor/FieldNpc.cs
@@ -181,7 +181,7 @@ public class FieldNpc : Actor<Npc> {
 
         playersListeningToDebug = playersListeningToDebugNow;
 
-        if (SendControl) {
+        if (SendControl && !IsDead) {
             SequenceCounter++;
             Field.BroadcastNpcControl(this);
             SendControl = false;


### PR DESCRIPTION
Fix npcs switching between idle and playing a constant animation
Fix npcs stuck in animation when they should be playing death animation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented control updates from being broadcast for NPCs that are dead.
  * Improved emote state handling to optionally skip transitioning to idle after certain actions, resulting in more accurate character behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->