### PR TITLE
Add support for `fisher_grade` condition type and update mastery handling

### DIFF
--- a/Maple2.Server.Game/Manager/MasteryManager.cs
+++ b/Maple2.Server.Game/Manager/MasteryManager.cs
@@ -1,4 +1,5 @@
-﻿using System.Numerics;
+﻿using System.Diagnostics;
+using System.Numerics;
 using Maple2.Model.Enum;
 using Maple2.Model.Error;
 using Maple2.Model.Game;
@@ -80,7 +81,11 @@ public class MasteryManager {
             session.Send(MasteryPacket.UpdateMastery(type, session.Mastery[type]));
             int currentLevel = GetLevel(type);
             if (startLevel < currentLevel || startValue == 0) {
-                session.ConditionUpdate(ConditionType.mastery_grade, codeLong: (int) type);
+                if (type == MasteryType.Fishing) {
+                    session.ConditionUpdate(ConditionType.fisher_grade, codeLong: currentLevel);
+                } else {
+                    session.ConditionUpdate(ConditionType.mastery_grade, codeLong: (int) type);
+                }
             }
             if (startLevel > currentLevel) {
                 session.ConditionUpdate(ConditionType.set_mastery_grade, codeLong: (int) type);

--- a/Maple2.Server.Game/Util/ConditionUtil.cs
+++ b/Maple2.Server.Game/Util/ConditionUtil.cs
@@ -59,6 +59,7 @@ public static class ConditionUtil {
                 break;
             case ConditionType.map:
             case ConditionType.fish:
+            case ConditionType.fisher_grade:
             case ConditionType.mastery_grade:
             case ConditionType.set_mastery_grade:
             case ConditionType.item_add:
@@ -265,6 +266,7 @@ public static class ConditionUtil {
             case ConditionType.fish_fail:
             case ConditionType.fish_collect:
             case ConditionType.fish_goldmedal:
+            case ConditionType.fisher_grade:
             case ConditionType.mastery_grade:
             case ConditionType.set_mastery_grade:
             case ConditionType.music_play_grade:


### PR DESCRIPTION
## Overview

Previously when the fishing mastery had been updated the session had been updated with `ConditionType.mastery_grade` and the mastery type. However for fishing this needs to be `ConditionType.fisher_grade` with the fishing level. Furthermore the Condition checks for code and target now support the `fisher_grade` type.

Refs: #33

### Video
https://github.com/user-attachments/assets/1e50ffa4-fc12-45c9-a715-5b100fdb50ab



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected fishing mastery grade updates to accurately reflect the current level.
  * Ensured fishing-related conditions properly evaluate fisher grade, improving reliability of checks.
  * Improved consistency for quests, achievements, and events that depend on fishing mastery progression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->