### PR TITLE
Add mastery commands for player management and debugging

### DIFF
--- a/Maple2.Server.Game/Commands/PlayerCommand.cs
+++ b/Maple2.Server.Game/Commands/PlayerCommand.cs
@@ -22,6 +22,68 @@ public class PlayerCommand : GameCommand {
         AddCommand(new CurrencyCommand(session));
         AddCommand(new InventoryCommand(session));
         AddCommand(new TrophyCommand(session, achievementMetadataStorage));
+        AddCommand(new MasteryCommand(session));
+    }
+
+    private class MasteryCommand : Command {
+        public MasteryCommand(GameSession session) : base("mastery", "Set player mastery.") {
+            AddCommand(new MasteryExpCommand(session));
+            AddCommand(new MasteryLevelCommand(session));
+        }
+
+        private class MasteryExpCommand : Command {
+            private readonly GameSession session;
+
+            public MasteryExpCommand(GameSession session) : base("exp", "Set player mastery experience.") {
+                this.session = session;
+
+                var masteryCode = new Argument<MasteryType>("mastery", "MasteryType of the player.");
+                var exp = new Argument<int>("exp", "Experience points to add.");
+
+                AddArgument(masteryCode);
+                AddArgument(exp);
+                this.SetHandler<InvocationContext, MasteryType, int>(Handle, masteryCode, exp);
+            }
+
+            private void Handle(InvocationContext ctx, MasteryType masteryType, int exp) {
+                try {
+                    session.Mastery[masteryType] = exp;
+                    ctx.ExitCode = 0;
+                } catch (SystemException ex) {
+                    ctx.Console.Error.WriteLine(ex.Message);
+                    ctx.ExitCode = 1;
+                }
+            }
+        }
+
+        private class MasteryLevelCommand : Command {
+            private readonly GameSession session;
+
+            public MasteryLevelCommand(GameSession session) : base("level", "Set player mastery level.") {
+                this.session = session;
+
+                var masteryCode = new Argument<MasteryType>("mastery", "MasteryType of the player.");
+                var level = new Argument<int>("level", "Level of the mastery.");
+
+                AddArgument(masteryCode);
+                AddArgument(level);
+                this.SetHandler<InvocationContext, MasteryType, int>(Handle, masteryCode, level);
+            }
+
+            private void Handle(InvocationContext ctx, MasteryType masteryType, int level) {
+                try {
+                    int exp = 0;
+                    if (session.TableMetadata.MasteryRewardTable.Entries.TryGetValue(masteryType, out IReadOnlyDictionary<int, MasteryRewardTable.Entry>? masteryRewardMetadata)) {
+                        exp = masteryRewardMetadata.OrderByDescending(mastery => mastery.Key).FirstOrDefault(mastery => level >= mastery.Key).Value.Value;
+                    }
+                    session.Mastery[masteryType] = exp;
+                    ctx.ExitCode = 0;
+                } catch (SystemException ex) {
+                    ctx.Console.Error.WriteLine(ex.Message);
+                    ctx.ExitCode = 1;
+                }
+            }
+        }
     }
 
     private class LevelCommand : Command {


### PR DESCRIPTION
## Overview

To better debug and test different mastery related features a new subcommand has been added to the player commands. This new subcommand allows for changing mastery exp/levels of the current player.

**Usage:**
`/player mastery <"exp"/"level"> <mastery> <exp/level>`

**Masteries**:
- `Fishing`
- `Music`
- `Mining`
- `Gathering`
- `Breeding`
- `Farming`
- `Blacksmithing`
- `Engraving`
- `Alchemist`
- `Cooking`
- `PetTaming`

**Examples:**
```
# Sets the Fishing Mastery to a total of 20 exp
/player mastery exp Fishing 20

# Sets the Fishing Mastery to level 2
/player mastery level Fishing 2
```


Not sure if this is needed or others find this helpful. If not feel free to close this Pull Request :)