### PR TITLE
Handling for `music_play_instrument_mastery` condition type

### DIFF
--- a/Maple2.Server.Game/Commands/PlayerCommand.cs
+++ b/Maple2.Server.Game/Commands/PlayerCommand.cs
@@ -27,18 +27,44 @@ public class PlayerCommand : GameCommand {
 
     private class MasteryCommand : Command {
         public MasteryCommand(GameSession session) : base("mastery", "Set player mastery.") {
-            AddCommand(new MasteryExpCommand(session));
+            AddCommand(new MasteryAddExpCommand(session));
+            AddCommand(new MasterySetExpCommand(session));
             AddCommand(new MasteryLevelCommand(session));
         }
 
-        private class MasteryExpCommand : Command {
+        private class MasteryAddExpCommand : Command {
             private readonly GameSession session;
 
-            public MasteryExpCommand(GameSession session) : base("exp", "Set player mastery experience.") {
+            public MasteryAddExpCommand(GameSession session) : base("addexp", "Add player mastery experience.") {
                 this.session = session;
 
                 var masteryCode = new Argument<MasteryType>("mastery", "MasteryType of the player.");
                 var exp = new Argument<int>("exp", "Experience points to add.");
+
+                AddArgument(masteryCode);
+                AddArgument(exp);
+                this.SetHandler<InvocationContext, MasteryType, int>(Handle, masteryCode, exp);
+            }
+
+            private void Handle(InvocationContext ctx, MasteryType masteryType, int exp) {
+                try {
+                    session.Mastery[masteryType] = session.Mastery[masteryType] + exp;
+                    ctx.ExitCode = 0;
+                } catch (SystemException ex) {
+                    ctx.Console.Error.WriteLine(ex.Message);
+                    ctx.ExitCode = 1;
+                }
+            }
+        }
+
+        private class MasterySetExpCommand : Command {
+            private readonly GameSession session;
+
+            public MasterySetExpCommand(GameSession session) : base("setexp", "Set player mastery experience.") {
+                this.session = session;
+
+                var masteryCode = new Argument<MasteryType>("mastery", "MasteryType of the player.");
+                var exp = new Argument<int>("exp", "Experience points to set to.");
 
                 AddArgument(masteryCode);
                 AddArgument(exp);

--- a/Maple2.Server.Game/Manager/AchievementManager.cs
+++ b/Maple2.Server.Game/Manager/AchievementManager.cs
@@ -166,6 +166,18 @@ public sealed class AchievementManager {
             return;
         }
 
+        bool hasMoreGrades = achievement.Metadata.Grades.Count > achievement.CurrentGrade;
+        // If an achievement has still more grade then we need to make sure the reward grade
+        // does not exceed the current grade. Else it will not show the correct trophy in
+        // the UI but rather the one past.
+        if (grade.Reward == null && hasMoreGrades) {
+            achievement.RewardGrade = Math.Min(achievement.RewardGrade + 1, achievement.CurrentGrade);
+            return;
+        }
+
+        // If an achievement has no reward and no further grade we need to push the reward grade
+        // past the current grade to mark it as fully completed. Else it will not show the crown
+        // and completion date for the trophy but rather the claim button which is not correct.
         if (grade.Reward == null) {
             achievement.RewardGrade++;
             return;

--- a/Maple2.Server.Game/Util/ConditionUtil.cs
+++ b/Maple2.Server.Game/Util/ConditionUtil.cs
@@ -110,6 +110,7 @@ public static class ConditionUtil {
             case ConditionType.holdtime:
             case ConditionType.riding:
             case ConditionType.fish_big:
+            case ConditionType.music_play_instrument_mastery:
             case ConditionType.music_play_instrument_time:
             case ConditionType.music_play_ensemble_in:
             case ConditionType.music_play_score:
@@ -271,6 +272,7 @@ public static class ConditionUtil {
             case ConditionType.set_mastery_grade:
             case ConditionType.music_play_grade:
             case ConditionType.music_play_ensemble:
+            case ConditionType.music_play_instrument_mastery:
             case ConditionType.item_add:
             case ConditionType.item_pickup:
             case ConditionType.item_destroy:


### PR DESCRIPTION
## Overview

Handling of mastery updates has been changed to properly update the `music_play_instrument_mastery`.
This now enables the following Trophies to work properly:
- https://handbook.tadeucci.dev/trophies/23100142
- https://handbook.tadeucci.dev/trophies/23100143
- https://handbook.tadeucci.dev/trophies/23100144
- https://handbook.tadeucci.dev/trophies/23100168
- https://handbook.tadeucci.dev/trophies/23100169
- https://handbook.tadeucci.dev/trophies/23100170
- https://handbook.tadeucci.dev/trophies/23100178
- https://handbook.tadeucci.dev/trophies/23100179
- https://handbook.tadeucci.dev/trophies/23100180
- https://handbook.tadeucci.dev/trophies/23100197
- https://handbook.tadeucci.dev/trophies/23100198
- https://handbook.tadeucci.dev/trophies/23100199
- https://handbook.tadeucci.dev/trophies/23100224
- https://handbook.tadeucci.dev/trophies/23100225
- https://handbook.tadeucci.dev/trophies/23100226
- https://handbook.tadeucci.dev/trophies/23100232
- https://handbook.tadeucci.dev/trophies/23100233
- https://handbook.tadeucci.dev/trophies/23100234
- https://handbook.tadeucci.dev/trophies/23100235
- https://handbook.tadeucci.dev/trophies/23100236
- https://handbook.tadeucci.dev/trophies/23100237
- https://handbook.tadeucci.dev/trophies/23100254
- https://handbook.tadeucci.dev/trophies/23100255
- https://handbook.tadeucci.dev/trophies/23100256
- https://handbook.tadeucci.dev/trophies/23100277
- https://handbook.tadeucci.dev/trophies/23100278
- https://handbook.tadeucci.dev/trophies/23100310
- https://handbook.tadeucci.dev/trophies/23100311
- https://handbook.tadeucci.dev/trophies/23100353
- https://handbook.tadeucci.dev/trophies/23100354
- https://handbook.tadeucci.dev/trophies/23100355
- https://handbook.tadeucci.dev/trophies/23100410
- https://handbook.tadeucci.dev/trophies/23100411
- https://handbook.tadeucci.dev/trophies/23100412
- https://handbook.tadeucci.dev/trophies/23100413

Furthermore the `/player mastery exp` command has been updated to now add exp rather then set the mastery value to the specified exp value as this causes issues for trophy tracking and is now more inline with the actual description.

Additionally the `RewardGrade` for Trophies has been miscalculated if they had no reward but had more additional grades that needed completing. Previously the `RewardGrade` had been increased past the actual `Grade` of the Trophy to mark it as completed. This was only correct for trophies that did not have additional `Grades` like e.g. music performance trophies causing the UI to skip to the next `Grade` (`VII`) for display although `V` was only completed and `VI` is still in progress.

Closes: #484
Refs: #33 

### Video

https://github.com/user-attachments/assets/56bade94-6174-4909-85df-7f546dec3cc4






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for evaluating music instrument mastery in conditions (enables related quests/achievements).

* **Bug Fixes**
  * Mastery EXP now accumulates correctly instead of overwriting progress.
  * Achievement rewards no longer skip ahead when a grade lacks a reward; trophy display and final-grade completion behave correctly.

* **Refactor**
  * Mastery update logic streamlined with improved, type-specific handling and enhanced debug logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->