### PR TITLE
Naive support for incoming mob damage

### DIFF
--- a/Maple2.Server.Game/Model/Field/Actor/ActorStateComponent/SkillState.cs
+++ b/Maple2.Server.Game/Model/Field/Actor/ActorStateComponent/SkillState.cs
@@ -2,6 +2,7 @@
 using Maple2.Model.Metadata;
 using Maple2.Server.Game.Model.Skill;
 using Maple2.Server.Game.Packets;
+using Maple2.Server.Game.Util;
 
 namespace Maple2.Server.Game.Model.ActorStateComponent;
 
@@ -63,6 +64,27 @@ public class SkillState {
 
         if (attack.CubeMagicPathId != 0) {
 
+        }
+
+        // Apply damage to targets server-side for NPC attacks
+        var resolvedTargets = new List<IActor>(attackTargets);
+        if (resolvedTargets.Count == 0) {
+            // Fallback: query targets from attack range
+            Maple2.Tools.Collision.Prism prism = attack.Range.GetPrism(actor.Position, actor.Rotation.Z);
+            foreach (IActor target in actor.Field.GetTargets(actor, new[] { prism }, attack.Range.ApplyTarget, attack.TargetCount)) {
+                resolvedTargets.Add(target);
+            }
+        }
+
+        if (resolvedTargets.Count > 0) {
+            int limit = attack.TargetCount > 0 ? attack.TargetCount : 1;
+            for (int i = 0; i < resolvedTargets.Count && i < limit; i++) {
+                IActor target = resolvedTargets[i];
+                cast.Targets.TryAdd(target.ObjectId, target);
+            }
+
+            // Reuse existing pipeline to calculate and broadcast damage/effects
+            actor.TargetAttack(cast);
         }
     }
 }


### PR DESCRIPTION
# What changed

## `Maple2.Server.Game/Model/Field/Actor/ActorStateComponent/SkillState.cs`

- After handling keyframe attack points, the server now:
    - Resolves targets:
      - Uses AI-provided `attackTargets` when present.
      - Falls back to a range query via `attack.Range.GetPrism(actor.Position, actor.Rotation.Z)` and `Field.GetTargets(...)` when empty.
    - Adds resolved targets to `cast.Targets`.
    - Calls `actor.TargetAttack(cast)` to reuse the established damage flow (DamageCalculator, HP updates via StatsPacket.Update, SkillDamagePacket.Damage, and effect triggers).

# Why this fixes it

- Previously, mobs broadcasted attack “Target” events, but never actually applied damage server‑side. Now, at each attack point, damage is calculated and applied the same way as player attacks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - NPC attacks reliably register hits and apply damage/effects, even when targets aren’t pre-specified.
  - Attacks now respect target caps, avoiding unintended multi-hit or no-hit scenarios.
  - Damage and hit notifications are consistently broadcast to players.

- Improvements
  - Standardized server-side handling of NPC attack targeting for more predictable combat.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->