### PR TITLE
fix(field): pass resolved pet metadata to FieldPet constructor after lookup failure handling

### DIFF
--- a/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.State.cs
+++ b/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.State.cs
@@ -130,6 +130,12 @@ public partial class FieldManager {
 
     public FieldPet? SpawnPet(Item pet, Vector3 position, Vector3 rotation, FieldMobSpawn? owner = null, FieldPlayer? player = null) {
         if (!NpcMetadata.TryGet(pet.Metadata.Property.PetId, out NpcMetadata? npc)) {
+            logger.Error("Failed to get npc metadata for pet id {PetId}", pet.Metadata.Property.PetId);
+            return null;
+        }
+
+        if (!ItemMetadata.TryGetPet(pet.Metadata.Property.PetId, out PetMetadata? petMetadata)) {
+            logger.Error("Failed to get pet metadata for pet id {PetId}", pet.Metadata.Property.PetId);
             return null;
         }
 
@@ -138,10 +144,7 @@ public partial class FieldManager {
         // We use GlobalId if there is an owner because players can move between maps.
         int objectId = player != null ? NextGlobalId() : NextLocalId();
         AnimationMetadata? animation = NpcMetadata.GetAnimation(npc.Model.Name);
-        if (!ItemMetadata.TryGetPet(pet.Metadata.Property.PetId, out PetMetadata? petMetadata)) {
-            logger.Error("Failed to get pet metadata for pet id {PetId}", pet.Metadata.Property.PetId);
-            return null;
-        }
+
         var fieldPet = new FieldPet(this, objectId, agent, new Npc(npc, animation), pet, petMetadata, Constant.PetFieldAiPath, player) {
             Owner = owner,
             Position = position,

--- a/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.State.cs
+++ b/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.State.cs
@@ -138,7 +138,11 @@ public partial class FieldManager {
         // We use GlobalId if there is an owner because players can move between maps.
         int objectId = player != null ? NextGlobalId() : NextLocalId();
         AnimationMetadata? animation = NpcMetadata.GetAnimation(npc.Model.Name);
-        var fieldPet = new FieldPet(this, objectId, agent, new Npc(npc, animation), pet, Constant.PetFieldAiPath, player) {
+        if (!ItemMetadata.TryGetPet(pet.Metadata.Property.PetId, out PetMetadata? petMetadata)) {
+            logger.Error("Failed to get pet metadata for pet id {PetId}", pet.Metadata.Property.PetId);
+            return null;
+        }
+        var fieldPet = new FieldPet(this, objectId, agent, new Npc(npc, animation), pet, petMetadata, Constant.PetFieldAiPath, player) {
             Owner = owner,
             Position = position,
             Rotation = rotation,

--- a/Maple2.Server.Game/Model/Field/Actor/FieldPet.cs
+++ b/Maple2.Server.Game/Model/Field/Actor/FieldPet.cs
@@ -24,13 +24,10 @@ public sealed class FieldPet : FieldNpc {
     public int TamingPoint;
     private long tamingTick;
 
-    public FieldPet(FieldManager field, int objectId, DtCrowdAgent agent, Npc npc, Item pet, string aiPath, FieldPlayer? owner = null) : base(field, objectId, agent, npc, aiPath) {
+    public FieldPet(FieldManager field, int objectId, DtCrowdAgent agent, Npc npc, Item pet, PetMetadata petMetadata, string aiPath, FieldPlayer? owner = null) : base(field, objectId, agent, npc, aiPath) {
         this.owner = owner;
         Pet = pet;
 
-        if (!field.ItemMetadata.TryGetPet(pet.Metadata.Property.PetId, out PetMetadata? petMetadata)) {
-            throw new KeyNotFoundException($"Pet metadata not found for pet id {pet.Id}");
-        }
         Metadata = petMetadata;
 
         // Wild pets need a TamingRank.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved stability when summoning pets by validating required pet data upfront and safely aborting if unavailable, reducing errors and potential crashes.
  - Enhanced error logging when pet data cannot be retrieved.

- Refactor
  - Pet creation now uses pre-fetched metadata supplied at spawn time instead of looking it up during initialization, making pet spawning more predictable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->