### PR TITLE
Fix - Item Creation Constant Rarity Error

### DIFF
--- a/Maple2.Server.Game/Manager/Items/ItemDropManager.cs
+++ b/Maple2.Server.Game/Manager/Items/ItemDropManager.cs
@@ -297,7 +297,7 @@ public class ItemDropManager {
         }
 
         if (rarity <= 0) {
-            if (itemMetadata.Option != null && itemMetadata.Option.ConstantId is < 6 and > 0) {
+            if (itemMetadata.Option != null && itemMetadata.Option.ConstantId is < 7 and > 0) {
                 rarity = itemMetadata.Option.ConstantId;
             } else {
                 rarity = 1;


### PR DESCRIPTION
When creating an item, the check for the item's fixed rarity (controlled by itemMetadata.Option.ConstantId) should be < 7 to correctly generate item with epic rarity(rarity = 6), rather than entering the else branch and using the default common rarity.

This bug was identified when disassembling epic weapons (for example: item ID 15000312), which should yield epic fragments (item ID 36000599). Instead, the fragments were incorrectly generated with common rarity, making further synthesis impossible.
The patch modifies the default rarity threshold during item creation to <7 (where epic rarity corresponds to level 6), ensuring correct creation of epic-tier items.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected item rarity assignment for certain drops so items at the highest option tier now display the proper rarity instead of defaulting to a lower value.
  * Improves accuracy of loot quality indicators, sorting, filters, and notifications.
  * Enhances consistency between item stats and displayed rarity across the game.
  * No changes to user settings or controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->