### PR TITLE
fix(ChangeAttributes): Fix wrong bonus value gen by Value Re-roller

### DIFF
--- a/Maple2.Server.Game/PacketHandlers/ChangeAttributesScrollHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/ChangeAttributesScrollHandler.cs
@@ -136,9 +136,16 @@ public class ChangeAttributesScrollHandler : FieldPacketHandler {
                 // Fixed attributes.
                 if (lockItem != null) {
                     // Restore locked attribute values.
-                    if (!ItemStatsCalc.UpdateFixedOption(ref changeItem, new LockOption((SpecialAttribute) attribute, true))) {
-                        session.Send(ChangeAttributesPacket.Error(ChangeAttributesError.s_itemremake_error_server_default));
-                        return;
+                    if (isSpecialAttribute) {
+                        if (!ItemStatsCalc.UpdateFixedOption(ref changeItem, new LockOption((SpecialAttribute) attribute, true))) {
+                            session.Send(ChangeAttributesPacket.Error(ChangeAttributesError.s_itemremake_error_server_default));
+                            return;
+                        }
+                    } else {
+                        if (!ItemStatsCalc.UpdateFixedOption(ref changeItem, new LockOption((BasicAttribute) attribute, true))) {
+                            session.Send(ChangeAttributesPacket.Error(ChangeAttributesError.s_itemremake_error_server_default));
+                            return;
+                        }
                     }
                 } else {
                     if (!ItemStatsCalc.UpdateFixedOption(ref changeItem)) {
@@ -146,6 +153,7 @@ public class ChangeAttributesScrollHandler : FieldPacketHandler {
                         return;
                     }
                 }
+
             }
 
             // Try to consume both items.

--- a/Maple2.Server.Game/Util/ItemStatsCalculator.cs
+++ b/Maple2.Server.Game/Util/ItemStatsCalculator.cs
@@ -184,7 +184,7 @@ public sealed class ItemStatsCalculator {
         return true;
     }
 
-    public bool UpdateFixedOption(ref Item item, params LockOption[] presets){
+    public bool UpdateFixedOption(ref Item item, params LockOption[] presets) {
         if (item.Metadata.Option == null || item.Stats == null) {
             return false;
         }
@@ -198,7 +198,9 @@ public sealed class ItemStatsCalculator {
         if (!TableMetadata.ItemOptionRandomTable.Options.TryGetValue(item.Metadata.Option.RandomId, item.Rarity, out ItemOption? itemOption)) {
             return false;
         }
-        ItemStats.Option fixedOption = new ItemStats.Option(option.Basic, option.Special, multiplyFactor: itemOption.MultiplyFactor);
+        var statResult = new Dictionary<BasicAttribute, BasicOption>(option.Basic);
+        var specialResult = new Dictionary<SpecialAttribute, SpecialOption>(option.Special);
+        var fixedOption = new ItemStats.Option(statResult, specialResult, multiplyFactor: itemOption.MultiplyFactor);
 
         if (!RandomizeValues(item, itemOption, ref fixedOption)) {
             return false;
@@ -208,10 +210,12 @@ public sealed class ItemStatsCalculator {
         foreach (LockOption lockOption in presets) {
             if (lockOption.TryGet(out BasicAttribute basic, out bool lockBasicValue)) {
                 if (lockBasicValue) {
+                    Debug.Assert(option.Basic.ContainsKey(basic), "Missing basic attribute after using lock.");
                     fixedOption.Basic[basic] = option.Basic[basic];
                 }
             } else if (lockOption.TryGet(out SpecialAttribute special, out bool lockSpecialValue)) {
                 if (lockSpecialValue) {
+                    Debug.Assert(option.Special.ContainsKey(special), "Missing special attribute after using lock.");
                     fixedOption.Special[special] = option.Special[special];
                 }
             }


### PR DESCRIPTION
…f two-handed weapons

# Changes

## `Maple2.Server.Game\PacketHandlers\ChangeAttributesScrollHandler.cs`

- Modified the handling logic for the in-game item "Bonus Value Re-roller" (e.g., ID 31001985) to align with the structure of "Bonus Re-roller"
- Implemented calls to the new processing interface `UpdateFixedOption` (as counterpart to `UpdateRandomOption`)

## `Maple2.Server.Game\Util\ItemStatsCalculator.cs`

- Created the `UpdateFixedOption` function following a similar structure to `UpdateRandomOption`
- The updated Option directly uses the Basic and Special values from the original Option, along with the `multiplyFactor` from the metadata's RandomTable

# Reason for Changes

Bug Symptom: When using the "Bonus Value Re-roller" item (e.g., ID 31001985), two-handed weapons would receive abnormal values that were lower than the minimum expected range.

Root Cause: The original logic failed to transfer the `multiplyFactor` between old and new Options, causing two-handed weapons to use the default `multiplyFactor = 1` and generate new values within **the same random range as one-handed weapons**.

Change 1:

> ```
> Maple2.Server.Game\PacketHandlers\ChangeAttributesScrollHandler.cs
> ```

Standardized the abstraction level by unifying attribute modification logic into the `ItemStatsCalculator.cs`

Change 2:

> ```
> Maple2.Server.Game\Util\ItemStatsCalculator.cs
> ```

Correctly implemented the transfer of `multiplyFactor` between Options

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Attribute Change Scrolls now apply fixed-attribute updates for both locked and unlocked stats, yielding more predictable reroll results.
  * Locked basic and special attributes are preserved during rerolls.

* **Bug Fixes**
  * Unified, clearer error responses on reroll failures.
  * Removes reliance on missing option data that could cause rare failures, improving stability and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->