### PR TITLE
fix ShowCaption trigger

### DIFF
--- a/Maple2.Server.Game/Trigger/TriggerContext.Cinematic.cs
+++ b/Maple2.Server.Game/Trigger/TriggerContext.Cinematic.cs
@@ -122,7 +122,12 @@ public partial class TriggerContext {
         int duration,
         float scale
     ) {
-        DebugLog("[ShowCaption] type:{Type}, title:{Title}, script:{Script}", type, title, script);
+        DebugLog("[ShowCaption] type:{Type}, title:{Title}, script:{Script} align:{Align}, offsetRateX:{OffsetRateX}, offsetRateY:{OffsetRateY}, duration:{Duration}, scale:{Scale}",
+            type, title, script, align, offsetRateX, offsetRateY, duration, scale);
+        // Not sure if this is correct, but I only found packets where NameCaption and offsetRateX and offsetRateY are both not 0 or both 0. even though in the trigger only one of them is set to a value.
+        if (type == "NameCaption" && (offsetRateX == 0 || offsetRateY == 0)) {
+            offsetRateX = offsetRateY = 0;
+        }
         Broadcast(CinematicPacket.Caption(type, title, script, align, offsetRateX, offsetRateY, duration, scale));
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected caption positioning for name-style captions when partial offsets were provided, ensuring consistent on-screen alignment.
  * Improved reliability of caption rendering by standardizing how offset values are applied.

* **Chores**
  * Expanded caption event logging to include alignment, X/Y offset rates, duration, and scale for better diagnostics.
  * Logging now reflects any adjustments made to offset values before broadcasting, aiding in troubleshooting without changing user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->