### PR TITLE
Fix item command and fix InventoryManager.Add

### DIFF
--- a/Maple2.Server.Game/Commands/ItemCommand.cs
+++ b/Maple2.Server.Game/Commands/ItemCommand.cs
@@ -4,6 +4,7 @@ using System.CommandLine.IO;
 using Maple2.Database.Storage;
 using Maple2.Model;
 using Maple2.Model.Enum;
+using Maple2.Model.Error;
 using Maple2.Model.Game;
 using Maple2.Server.Game.Model;
 using Maple2.Server.Game.Packets;
@@ -41,7 +42,7 @@ public class ItemCommand : GameCommand {
         try {
             rarity = Math.Clamp(rarity, 1, MAX_RARITY);
 
-            Item? firstItem = session.Field?.ItemDrop.CreateItem(itemId, rarity, rollMax: rollMax);
+            Item? firstItem = session.Field.ItemDrop.CreateItem(itemId, rarity, rollMax: rollMax);
             if (firstItem == null) {
                 ctx.Console.Error.WriteLine($"Invalid Item: {itemId}");
                 return;
@@ -49,33 +50,64 @@ public class ItemCommand : GameCommand {
 
             if (firstItem.IsCurrency()) {
                 firstItem.Amount = amount;
-                ProcessSingleItem(ctx, firstItem, drop);
+                ctx.ExitCode = GiveItem(ctx, firstItem) ? 0 : 1;
                 return;
             }
 
-            bool isNonStackable = firstItem.Metadata.Property.SlotMax == 0;
-            if (isNonStackable) {
-                ctx.Console.Error.WriteLine($"{itemId} has SlotMax of 0, ignoring...");
-                amount = Math.Clamp(amount, 1, int.MaxValue);
+            bool isNonStackable = firstItem.Metadata.Property.SlotMax == 1;
+
+            if (drop) {
+                if (isNonStackable) {
+                    // Apply hard cap only when dropping non-stackable items
+                    amount = Math.Clamp(amount, 1, 100);
+
+                    DropItem(firstItem);
+                    for (int i = 1; i < amount; i++) {
+                        Item? additionalItem = session.Field.ItemDrop.CreateItem(itemId, rarity, rollMax: rollMax);
+                        if (additionalItem == null) {
+                            ctx.Console.Error.WriteLine($"Failed to create additional item {i + 1}/{amount}");
+                            continue;
+                        }
+                        DropItem(additionalItem);
+                    }
+                } else {
+                    // Stackable items can be dropped as a single stack only up to SlotMax
+                    firstItem.Amount = Math.Clamp(amount, 1, firstItem.Metadata.Property.SlotMax);
+                    DropItem(firstItem);
+                }
+                ctx.ExitCode = 0;
+                return;
             }
 
-            // For non-stackable items or when rollMax is enabled, create individual items
-            if (isNonStackable || (rollMax && amount > 1)) {
-                ProcessSingleItem(ctx, firstItem, drop);
+            if (isNonStackable) {
+                int freeSlots = session.Item.Inventory.FreeSlots(firstItem.Inventory);
+                if (freeSlots <= 0) {
+                    session.Send(ItemInventoryPacket.Error(ItemInventoryError.s_err_inventory));
+                    return;
+                }
+                if (!GiveItem(ctx, firstItem)) {
+                    return;
+                }
 
+                amount = Math.Clamp(amount, 1, freeSlots);
+                // don't need to recalculate free slots, since we are skipping one already
                 for (int i = 1; i < amount; i++) {
-                    Item? additionalItem = session.Field?.ItemDrop.CreateItem(itemId, rarity, rollMax: rollMax);
+                    Item? additionalItem = session.Field.ItemDrop.CreateItem(itemId, rarity, rollMax: rollMax);
                     if (additionalItem == null) {
                         ctx.Console.Error.WriteLine($"Failed to create additional item {i + 1}/{amount}");
                         continue;
                     }
-
-                    ProcessSingleItem(ctx, additionalItem, drop);
+                    if (!GiveItem(ctx, additionalItem)) {
+                        return;
+                    }
                 }
             } else {
                 firstItem.Amount = amount;
-                ProcessSingleItem(ctx, firstItem, drop);
+                if (!GiveItem(ctx, firstItem)) {
+                    return;
+                }
             }
+
 
             ctx.ExitCode = 0;
         } catch (SystemException ex) {
@@ -84,14 +116,17 @@ public class ItemCommand : GameCommand {
         }
     }
 
-    private void ProcessSingleItem(InvocationContext ctx, Item item, bool drop) {
-        if (drop && session.Field != null) {
-            FieldItem fieldItem = session.Field.SpawnItem(session.Player, item);
-            session.Field.Broadcast(FieldPacket.DropItem(fieldItem));
-        } else if (!session.Item.Inventory.Add(item, true)) {
-            session.Item.Inventory.Discard(item);
-            ctx.Console.Error.WriteLine($"Failed to add item:{item.Id} to inventory");
-            ctx.ExitCode = 1;
-        }
+    private void DropItem(Item item) {
+        if (session.Field is null) return;
+        FieldItem fieldItem = session.Field.SpawnItem(session.Player, item);
+        session.Field.Broadcast(FieldPacket.DropItem(fieldItem));
+    }
+
+    private bool GiveItem(InvocationContext ctx, Item item) {
+        if (session.Item.Inventory.Add(item, true)) return true;
+        session.Item.Inventory.Discard(item);
+        ctx.Console.Error.WriteLine($"Failed to add item:{item.Id} to inventory");
+        ctx.ExitCode = 1;
+        return false;
     }
 }

--- a/Maple2.Server.Game/Commands/ItemCommand.cs
+++ b/Maple2.Server.Game/Commands/ItemCommand.cs
@@ -61,19 +61,19 @@ public class ItemCommand : GameCommand {
                     // Apply hard cap only when dropping non-stackable items
                     amount = Math.Clamp(amount, 1, 100);
 
-                    DropItem(firstItem);
+                    session.Field.DropItem(session.Player, firstItem);
                     for (int i = 1; i < amount; i++) {
                         Item? additionalItem = session.Field.ItemDrop.CreateItem(itemId, rarity, rollMax: rollMax);
                         if (additionalItem == null) {
                             ctx.Console.Error.WriteLine($"Failed to create additional item {i + 1}/{amount}");
                             continue;
                         }
-                        DropItem(additionalItem);
+                        session.Field.DropItem(session.Player, additionalItem);
                     }
                 } else {
                     // Stackable items can be dropped as a single stack only up to SlotMax
                     firstItem.Amount = Math.Clamp(amount, 1, firstItem.Metadata.Property.SlotMax);
-                    DropItem(firstItem);
+                    session.Field.DropItem(session.Player, firstItem);
                 }
                 ctx.ExitCode = 0;
                 return;
@@ -114,12 +114,6 @@ public class ItemCommand : GameCommand {
             ctx.Console.Error.WriteLine(ex.Message);
             ctx.ExitCode = 1;
         }
-    }
-
-    private void DropItem(Item item) {
-        if (session.Field is null) return;
-        FieldItem fieldItem = session.Field.SpawnItem(session.Player, item);
-        session.Field.Broadcast(FieldPacket.DropItem(fieldItem));
     }
 
     private bool GiveItem(InvocationContext ctx, Item item) {

--- a/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.State.cs
+++ b/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.State.cs
@@ -280,7 +280,7 @@ public partial class FieldManager {
         Broadcast(FieldPacket.DropItem(fieldItem));
     }
 
-    public void DropItem( Vector3 position, Vector3 rotation, Item item, IFieldEntity? owner = null,long characterId = 0, bool fixedPosition = false) {
+    public void DropItem(Vector3 position, Vector3 rotation, Item item, IFieldEntity? owner = null, long characterId = 0, bool fixedPosition = false) {
         FieldItem fieldItem = SpawnItem(position, rotation, item, owner, characterId, fixedPosition);
         Broadcast(FieldPacket.DropItem(fieldItem));
     }

--- a/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.State.cs
+++ b/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.State.cs
@@ -261,8 +261,9 @@ public partial class FieldManager {
         return fieldItem;
     }
 
-    public FieldItem SpawnItem(Vector3 position, Vector3 rotation, Item item, long characterId = 0, bool fixedPosition = false) {
+    public FieldItem SpawnItem(Vector3 position, Vector3 rotation, Item item, IFieldEntity? owner, long characterId = 0, bool fixedPosition = false) {
         var fieldItem = new FieldItem(this, NextLocalId(), item) {
+            Owner = owner,
             Position = position,
             Rotation = rotation,
             FixedPosition = fixedPosition,
@@ -274,17 +275,14 @@ public partial class FieldManager {
         return fieldItem;
     }
 
-    public FieldItem SpawnItem(IFieldEntity owner, Vector3 position, Vector3 rotation, Item item, long characterId) {
-        var fieldItem = new FieldItem(this, NextLocalId(), item) {
-            Owner = owner,
-            Position = position,
-            Rotation = rotation,
-            ReceiverId = characterId,
-            Type = characterId > 0 ? DropType.Default : DropType.Player,
-        };
-        fieldItems[fieldItem.ObjectId] = fieldItem;
+    public void DropItem(IActor owner, Item item) {
+        FieldItem fieldItem = SpawnItem(owner, item);
+        Broadcast(FieldPacket.DropItem(fieldItem));
+    }
 
-        return fieldItem;
+    public void DropItem( Vector3 position, Vector3 rotation, Item item, IFieldEntity? owner = null,long characterId = 0, bool fixedPosition = false) {
+        FieldItem fieldItem = SpawnItem(position, rotation, item, owner, characterId, fixedPosition);
+        Broadcast(FieldPacket.DropItem(fieldItem));
     }
 
     public FieldBreakable? AddBreakable(string entityId, BreakableActor breakable) {

--- a/Maple2.Server.Game/Manager/Field/FieldManager/IField.cs
+++ b/Maple2.Server.Game/Manager/Field/FieldManager/IField.cs
@@ -71,8 +71,10 @@ public interface IField : IDisposable {
 
 
     public FieldItem SpawnItem(IActor owner, Item item);
-    public FieldItem SpawnItem(Vector3 position, Vector3 rotation, Item item, long characterId = 0, bool fixedPosition = false);
-    public FieldItem SpawnItem(IFieldEntity owner, Vector3 position, Vector3 rotation, Item item, long characterId);
+    public FieldItem SpawnItem(Vector3 position, Vector3 rotation, Item item, IFieldEntity? owner = null, long characterId = 0, bool fixedPosition = false);
+
+    public void DropItem(IActor owner, Item item);
+    public void DropItem(Vector3 position, Vector3 rotation, Item item, IFieldEntity? owner = null, long characterId = 0, bool fixedPosition = false);
 
     public void EnsurePlayerPosition(FieldPlayer player);
     public bool TryGetPlayerById(long characterId, [NotNullWhen(true)] out FieldPlayer? player);

--- a/Maple2.Server.Game/Manager/Items/InventoryManager.cs
+++ b/Maple2.Server.Game/Manager/Items/InventoryManager.cs
@@ -189,7 +189,10 @@ public class InventoryManager {
                     totalAmount -= toFill;
                     Item? itemToStack = session.Field.ItemDrop.CreateItem(add.Id, add.Rarity, toFill);
                     if (itemToStack is null) return false;
-                    Add(itemToStack, notifyNew, commit);
+                    if (!Add(itemToStack, notifyNew, commit)) {
+                        logger.Error("Failed to add partial stack during multi-step stacking");
+                        return false;
+                    }
                 }
 
                 int fullStacks = totalAmount / slotMax;

--- a/Maple2.Server.Game/Manager/Items/InventoryManager.cs
+++ b/Maple2.Server.Game/Manager/Items/InventoryManager.cs
@@ -148,6 +148,11 @@ public class InventoryManager {
 
     public bool Add(Item add, bool notifyNew = false, bool commit = false) {
         lock (session.Item) {
+            if (session.Field is null) {
+                logger.Warning("Tried to add item while not in a field");
+                return false;
+            }
+
             if (add.IsCurrency()) {
                 AddCurrency(add);
                 session.Item.Inventory.Discard(add);
@@ -171,28 +176,45 @@ public class InventoryManager {
                 return false;
             }
 
-            if (add.Metadata.Property.SlotMax == 1 && add.Amount > 1) {
-                if (items.OpenSlots < add.Amount) {
+            // Unified logic for stack splitting (works for both SlotMax == 1 and SlotMax > 1)
+            int slotMax = Math.Max(1, add.Metadata.Property.SlotMax);
+            if (add.Amount > slotMax) {
+                int totalAmount = add.Amount;
+
+                // 1. Fill partially filled stacks first
+                foreach (Item existing in items.Where(x => x.Id == add.Id && x.Rarity == add.Rarity && x.Amount < slotMax && !x.IsExpired())) {
+                    int canFill = slotMax - existing.Amount;
+                    int toFill = Math.Min(canFill, totalAmount);
+                    if (toFill <= 0) continue;
+                    totalAmount -= toFill;
+                    Item? itemToStack = session.Field.ItemDrop.CreateItem(add.Id, add.Rarity, toFill);
+                    if (itemToStack is null) return false;
+                    Add(itemToStack, notifyNew, commit);
+                }
+
+                int fullStacks = totalAmount / slotMax;
+                int remainder = totalAmount % slotMax;
+                int stacksNeeded = fullStacks + (remainder > 0 ? 1 : 0);
+
+                if (items.OpenSlots < stacksNeeded) {
                     session.Send(ItemInventoryPacket.Error(s_err_inventory));
                     return false;
                 }
-                int totalAmount = add.Amount;
-                add.Amount = 1;
 
-                if (!Add(add, notifyNew, commit)) {
-                    return false;
+                // 2. Add full stacks
+                for (int i = 0; i < fullStacks; i++) {
+                    Item? stackItem = session.Field.ItemDrop.CreateItem(add.Id, add.Rarity);
+                    if (stackItem is null) return false;
+                    stackItem.Amount = slotMax;
+                    if (!Add(stackItem, notifyNew, commit)) return false;
                 }
 
-                // Create and add individual copies for remaining items
-                for (int i = 1; i < totalAmount; i++) {
-                    Item? copy = session.Field?.ItemDrop.CreateItem(add.Id, add.Rarity);
-                    if (copy is null) {
-                        return false;
-                    }
-
-                    if (!Add(copy, notifyNew, commit)) {
-                        return false;
-                    }
+                // 3. Add remainder stack
+                if (remainder > 0) {
+                    Item? remainderItem = session.Field.ItemDrop.CreateItem(add.Id, add.Rarity);
+                    if (remainderItem is null) return false;
+                    remainderItem.Amount = remainder;
+                    if (!Add(remainderItem, notifyNew, commit)) return false;
                 }
 
                 return true;

--- a/Maple2.Server.Game/Manager/MasteryManager.cs
+++ b/Maple2.Server.Game/Manager/MasteryManager.cs
@@ -207,8 +207,7 @@ public class MasteryManager {
             if (item == null || session.Field is null) {
                 continue;
             }
-            FieldItem fieldItem = session.Field.SpawnItem(position, rotation, item, session.CharacterId);
-            session.Field.Broadcast(FieldPacket.DropItem(fieldItem));
+            session.Field.DropItem(position, rotation, item, characterId: session.CharacterId);
         }
 
         AfterGather(recipeMetadata, 1);

--- a/Maple2.Server.Game/Model/Field/Actor/FieldNpc.cs
+++ b/Maple2.Server.Game/Model/Field/Actor/FieldNpc.cs
@@ -365,8 +365,7 @@ public class FieldNpc : Actor<Npc> {
             float y = Random.Shared.Next((int) Position.Y - Value.Metadata.DropInfo.DropDistanceRandom, (int) Position.Y + Value.Metadata.DropInfo.DropDistanceRandom);
             var position = new Vector3(x, y, Position.Z);
 
-            FieldItem fieldItem = Field.SpawnItem(this, position, Rotation, item, firstPlayer.Value.Character.Id);
-            Field.Broadcast(FieldPacket.DropItem(fieldItem));
+            Field.DropItem( position, Rotation, item, owner:this, characterId: firstPlayer.Value.Character.Id);
         }
     }
 

--- a/Maple2.Server.Game/Model/Field/Actor/FieldNpc.cs
+++ b/Maple2.Server.Game/Model/Field/Actor/FieldNpc.cs
@@ -365,7 +365,7 @@ public class FieldNpc : Actor<Npc> {
             float y = Random.Shared.Next((int) Position.Y - Value.Metadata.DropInfo.DropDistanceRandom, (int) Position.Y + Value.Metadata.DropInfo.DropDistanceRandom);
             var position = new Vector3(x, y, Position.Z);
 
-            Field.DropItem( position, Rotation, item, owner:this, characterId: firstPlayer.Value.Character.Id);
+            Field.DropItem(position, Rotation, item, owner: this, characterId: firstPlayer.Value.Character.Id);
         }
     }
 

--- a/Maple2.Server.Game/PacketHandlers/BreakableHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/BreakableHandler.cs
@@ -47,7 +47,7 @@ public class BreakableHandler : FieldPacketHandler {
             if (breakable.Value.GlobalDropBoxId != 0) {
                 ICollection<Item> items = session.Field.ItemDrop.GetGlobalDropItems(breakable.Value.GlobalDropBoxId, session.Field.Metadata.Drop.Level);
                 foreach (Item item in items) {
-                    session.Field.DropItem(breakable.Position, breakable.Rotation, item, owner:breakable, characterId:session.CharacterId);
+                    session.Field.DropItem(breakable.Position, breakable.Rotation, item, owner: breakable, characterId: session.CharacterId);
                 }
             }
             session.ConditionUpdate(ConditionType.breakable_object);

--- a/Maple2.Server.Game/PacketHandlers/BreakableHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/BreakableHandler.cs
@@ -47,8 +47,7 @@ public class BreakableHandler : FieldPacketHandler {
             if (breakable.Value.GlobalDropBoxId != 0) {
                 ICollection<Item> items = session.Field.ItemDrop.GetGlobalDropItems(breakable.Value.GlobalDropBoxId, session.Field.Metadata.Drop.Level);
                 foreach (Item item in items) {
-                    FieldItem fieldItem = session.Field.SpawnItem(breakable, breakable.Position, breakable.Rotation, item, session.CharacterId);
-                    session.Field.Broadcast(FieldPacket.DropItem(fieldItem));
+                    session.Field.DropItem(breakable.Position, breakable.Rotation, item, owner:breakable, characterId:session.CharacterId);
                 }
             }
             session.ConditionUpdate(ConditionType.breakable_object);

--- a/Maple2.Server.Game/PacketHandlers/FunctionCubeHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/FunctionCubeHandler.cs
@@ -123,8 +123,7 @@ public class FunctionCubeHandler : FieldPacketHandler {
                 return;
             }
             // drop the item
-            FieldItem fieldRewardStageItem = session.Field.SpawnItem(session.Player, fieldCube.Position, fieldCube.Rotation, rewardStageItem, session.CharacterId);
-            session.Field.Broadcast(FieldPacket.DropItem(fieldRewardStageItem));
+            session.Field.DropItem(fieldCube.Position, fieldCube.Rotation, rewardStageItem, owner: session.Player, characterId: session.CharacterId);
             db.UpdateNurturing(session.AccountId, fieldCube.InteractCube);
 
             session.Field.Broadcast(FunctionCubePacket.UpdateFunctionCube(fieldCube.InteractCube));
@@ -148,13 +147,12 @@ public class FunctionCubeHandler : FieldPacketHandler {
         }
 
         // drop the item
-        FieldItem fieldItem = session.Field.SpawnItem(session.Player, fieldCube.Position, fieldCube.Rotation, rewardItem, session.CharacterId);
-        session.Field.Broadcast(FieldPacket.DropItem(fieldItem));
+        session.Field.DropItem(fieldCube.Position, fieldCube.Rotation, rewardItem, owner: session.Player, characterId: session.CharacterId);
         nurturing.Feed();
         db.UpdateNurturing(session.AccountId, fieldCube.InteractCube);
 
         session.Field.Broadcast(FunctionCubePacket.UpdateFunctionCube(fieldCube.InteractCube));
-        session.Send(FunctionCubePacket.Feed(fieldItem.Value.Uid, fieldCube.CubeId, fieldCube.InteractCube));
+        session.Send(FunctionCubePacket.Feed(rewardItem.Uid, fieldCube.CubeId, fieldCube.InteractCube));
     }
 
     private void HandlePlayNurturing(GameSession session, Plot plot, FieldFunctionInteract cube, Nurturing nurturing, GameStorage.Request db) {
@@ -182,8 +180,7 @@ public class FunctionCubeHandler : FieldPacketHandler {
         }
 
         // drop the item
-        FieldItem fieldItem = session.Field.SpawnItem(session.Player, cube.Position, cube.Rotation, rewardItem, session.CharacterId);
-        session.Field.Broadcast(FieldPacket.DropItem(fieldItem));
+        session.Field.DropItem(cube.Position, cube.Rotation, rewardItem, owner: session.Player, characterId: session.CharacterId);
 
         db.UpdateNurturing(plot.OwnerId, cube.InteractCube);
 

--- a/Maple2.Server.Game/PacketHandlers/InteractObjectHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/InteractObjectHandler.cs
@@ -95,17 +95,15 @@ public class InteractObjectHandler : FieldPacketHandler {
             }
 
             foreach (Item item in globalDropBoxItems) {
-                FieldItem fieldItem = session.Field.SpawnItem(interact, interact.Position with {
+                session.Field.DropItem(interact.Position with {
                     Z = interact.Position.Z + interact.Value.Drop.DropHeight,
-                }, interact.Rotation, item, session.CharacterId);
-                session.Field.Broadcast(FieldPacket.DropItem(fieldItem));
+                }, interact.Rotation, item, owner: interact, characterId: session.CharacterId);
             }
 
             foreach (Item item in items) {
-                FieldItem fieldItem = session.Field.SpawnItem(interact, interact.Position with {
+                session.Field.DropItem(interact.Position with {
                     Z = interact.Position.Z + interact.Value.Drop.DropHeight,
-                }, interact.Rotation, item, session.CharacterId);
-                session.Field.Broadcast(FieldPacket.DropItem(fieldItem));
+                }, interact.Rotation, item, owner: interact, characterId: session.CharacterId);
             }
 
             foreach (InteractObjectMetadataEffect.InvokeEffect invokeEffect in interact.Value.AdditionalEffect.Invoke) {

--- a/Maple2.Server.Game/PacketHandlers/ItemInventoryHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/ItemInventoryHandler.cs
@@ -114,7 +114,6 @@ public class ItemInventoryHandler : FieldPacketHandler {
             return;
         }
 
-        FieldItem fieldItem = session.Field.SpawnItem(session.Player, drop);
-        session.Field.Broadcast(FieldPacket.DropItem(fieldItem));
+        session.Field.DropItem(session.Player, drop);
     }
 }

--- a/Maple2.Server.Game/Trigger/TriggerContext.Field.cs
+++ b/Maple2.Server.Game/Trigger/TriggerContext.Field.cs
@@ -416,9 +416,8 @@ public partial class TriggerContext {
             }
 
             foreach (Item item in items) {
-                FieldItem fieldItem = Field.SpawnItem(spawn.Position, spawn.Rotation, item, 0, true);
+                 Field.DropItem(spawn.Position, spawn.Rotation, item, characterId: 0, fixedPosition:true);
 
-                Field.Broadcast(FieldPacket.DropItem(fieldItem));
             }
         }
     }
@@ -443,9 +442,7 @@ public partial class TriggerContext {
             }
 
             foreach (Item item in items) {
-                FieldItem fieldItem = Field.SpawnItem(spawn.Position, spawn.Rotation, item, 0, true);
-
-                Field.Broadcast(FieldPacket.DropItem(fieldItem));
+                Field.DropItem(spawn.Position, spawn.Rotation, item, characterId: 0, fixedPosition:true);
             }
         }
     }

--- a/Maple2.Server.Game/Trigger/TriggerContext.Field.cs
+++ b/Maple2.Server.Game/Trigger/TriggerContext.Field.cs
@@ -416,7 +416,7 @@ public partial class TriggerContext {
             }
 
             foreach (Item item in items) {
-                 Field.DropItem(spawn.Position, spawn.Rotation, item, characterId: 0, fixedPosition:true);
+                Field.DropItem(spawn.Position, spawn.Rotation, item, characterId: 0, fixedPosition: true);
 
             }
         }
@@ -442,7 +442,7 @@ public partial class TriggerContext {
             }
 
             foreach (Item item in items) {
-                Field.DropItem(spawn.Position, spawn.Rotation, item, characterId: 0, fixedPosition:true);
+                Field.DropItem(spawn.Position, spawn.Rotation, item, characterId: 0, fixedPosition: true);
             }
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Centralized drop API for field drops; unified handling distinguishes dropping vs. adding to inventory.
  - Safeguard prevents adding items when not in a valid field/session.

- **Bug Fixes**
  - Non-stackable drops capped at 100 per action; extras spawn as additional items.
  - Stackable items clamp to max stack size and drop/add as a single stack.
  - Inventory adds now fill partial stacks first, validate free slots up front, and surface clearer inventory errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->