### PR TITLE
Enable "Enter Alone" button for tracked quest

### DIFF
--- a/Maple2.Server.Game/PacketHandlers/QuestHandler.cs
+++ b/Maple2.Server.Game/PacketHandlers/QuestHandler.cs
@@ -198,7 +198,7 @@ public class QuestHandler : FieldPacketHandler {
     private static void HandleGoToDungeon(GameSession session, IByteReader packet) {
         int questId = packet.ReadInt();
 
-        if (!session.Quest.TryGetQuest(questId, out Quest? quest)) {
+        if (!session.Quest.TryGetQuest(questId, out Quest? quest) || quest.State != QuestState.Started) {
             return;
         }
 


### PR DESCRIPTION
# Changes

## `Maple2\Maple2.Server.Game\PacketHandlers\QuestHandler.cs`

* Added `HandleGoToDungeon` within `Handle` logic.

<img width="403" height="174" alt="image" src="https://github.com/user-attachments/assets/14a05c5a-92cb-4da4-b39a-a264869bbacc" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Players can now transition directly into dungeons from quest interactions when the quest is active.
  * If the quest cannot be resolved or isn't started, the game will not attempt a transition and will ignore the request silently.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->