### PR TITLE
Prism NPC detection

### DIFF
--- a/Maple2.Model/Game/TriggerObject.cs
+++ b/Maple2.Model/Game/TriggerObject.cs
@@ -120,6 +120,8 @@ public class TriggerBox {
 
     public bool Contains(in Vector3 point) => box.Contains(point);
 
+    public bool Intersects(in IPrism shape) => box.Intersects(shape);
+
     public override string ToString() {
         return $"Id:{Id}\n- {box}";
     }

--- a/Maple2.Server.Game/Trigger/TriggerContext.Npc.cs
+++ b/Maple2.Server.Game/Trigger/TriggerContext.Npc.cs
@@ -274,7 +274,7 @@ public partial class TriggerContext {
             .Select(boxId => Objects.Boxes.GetValueOrDefault(boxId))
             .Where(box => box != null)!;
 
-        return Field.EnumerateNpcs().Where(mob => boxes.Any(box => box.Contains(mob.Position)));
+        return Field.EnumerateNpcs().Where(mob => boxes.Any(box => box.Contains(mob.Position) || box.Intersects(mob.Shape)));
     }
 
     private void SpawnNpc(int spawnId, bool useSpawnAnimation = false) {


### PR DESCRIPTION
# Maple2.Server.Game/Trigger/TriggerContext.Npc.cs

Currently, the NPC location / position check is using an exact match. For bugs like [Twinkling Path](https://discordapp.com/channels/1361469107735888072/1453502417957032107) being blocked by NPCs being in the "right position" but not in the "exact position", the quest was unable to progress after finding the first child due to this minor difference in position.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NPC detection in trigger areas. NPCs are now correctly identified when trigger box boundaries intersect with their shapes, enhancing spawn and detection logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->