### PR TITLE
Reorder trigger and portal initialization in FieldManager

### DIFF
--- a/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.cs
+++ b/Maple2.Server.Game/Manager/Field/FieldManager/FieldManager.cs
@@ -160,13 +160,6 @@ public partial class FieldManager : IField {
                 new UgcMapGroup.Limits(0, 0, 0, 0, 0, 0)));
         }
 
-        foreach (TriggerModel trigger in Entities.TriggerModels.Values) {
-            AddTrigger(trigger);
-        }
-        foreach (Portal portal in Entities.Portals.Values) {
-            SpawnPortal(portal);
-        }
-
         foreach ((Guid guid, BreakableActor breakable) in Entities.BreakableActors) {
             AddBreakable(guid.ToString("N"), breakable);
         }
@@ -183,6 +176,18 @@ public partial class FieldManager : IField {
 
         foreach ((int id, SpawnPointPC spawnPoint) in Entities.PlayerSpawns) {
             fieldPlayerSpawnPoints[id] = new FieldPlayerSpawnPoint(this, NextLocalId(), spawnPoint);
+        }
+
+        foreach (TriggerModel trigger in Entities.TriggerModels.Values) {
+            AddTrigger(trigger);
+        }
+
+        foreach (Portal portal in Entities.Portals.Values) {
+            SpawnPortal(portal);
+        }
+
+        foreach (FieldTrigger trigger in fieldTriggers.Values) {
+            trigger.Update(FieldTick);
         }
 
         IList<MapMetadata> bonusMaps = MapMetadata.GetMapsByType(Metadata.Property.Continent, MapType.PocketRealm);


### PR DESCRIPTION
Moved the initialization of triggers and portals to occur after player spawn points are set up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved field initialization sequence to ensure triggers and portals are properly registered during map loading.
  * Enhanced trigger update handling during initialization for better game state consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->