### PR TITLE
Remove session disconnect after listing servers due to it causing a p…

### DIFF
--- a/Maple2.Server.Login/PacketHandlers/LoginHandler.cs
+++ b/Maple2.Server.Login/PacketHandlers/LoginHandler.cs
@@ -84,7 +84,6 @@ public class LoginHandler : PacketHandler<LoginSession> {
             switch (command) {
                 case Command.ServerList:
                     session.ListServers();
-                    session.Disconnect();
                     return;
                 case Command.CharacterList:
                     session.Init(response.AccountId, machineId);


### PR DESCRIPTION
…roblem with subsequent logins with the same credentials after quitting the game.

Resolves issue #628, which seems to be caused by PR #430.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed an issue where the login session would disconnect immediately after viewing available servers, preventing users from completing the login process to select a server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->