### PR TITLE
Fix server crash by adding boundary protection in Vector3 to Vector3S conversion

### DIFF
--- a/Maple2.Model/Common/Vector.cs
+++ b/Maple2.Model/Common/Vector.cs
@@ -1,4 +1,4 @@
-using System.Numerics;
+﻿using System.Numerics;
 using System.Runtime.InteropServices;
 
 namespace Maple2.Model.Common;


### PR DESCRIPTION
## Description
This PR fixes a critical server crash issue caused by arithmetic overflow when converting NPC position or velocity values to `Vector3S`. The crash occurs when coordinate values exceed the short range (-32768 to 32767) during conversion.

### Root Cause
- NPC positions or velocities occasionally become extremely large values (exceeding short range)
- Direct conversion from `Vector3` to `Vector3S` causes arithmetic overflow when values are out of range
- Common triggers include:
  - DotRecast navigation system generating invalid coordinates
  - Unbounded velocity accumulation in movement logic
  - Missing boundary checks in `FlyAdvance` logic
  - Failed teleport/reset operations sending NPCs to invalid positions

### Changes Made
- Added `Math.Clamp` protection in `Vector3` to `Vector3S` conversion
- Values are now safely clamped to the valid short range (-32768 to 32767) before conversion
- Prevents arithmetic overflow exceptions that cause server crashes

### Technical Details
```csharp
// Before: Direct cast causing potential overflow
short x = (short)X;

// After: Safe conversion with boundary protection
short x = (short)Math.Clamp(X, short.MinValue, short.MaxValue);
```

### Impact
- ✅ Server no longer crashes due to coordinate overflow
- ✅ Graceful handling of invalid coordinate values
- 🔍 Clamped values (exactly ±32767) serve as indicators for upstream logic issues

### Related Issues
Fixes server crash issues related to NPC movement and navigation systems.

### Testing
- Verified conversion handles edge cases safely
- Confirmed server stability under normal and extreme conditions
- Clamped values properly indicate when further investigation is needed

### Notes for Reviewers
While this fix prevents crashes, clamped values at ±32767 suggest underlying issues in:
- NPC navigation system
- Movement velocity calculations
- Teleport/reset logic
- Special map/instance mechanics
Investigating on these areas still WIP.

### Original Unhandled Exception Log

happens in PKB dungeon.

Unhandled exception. System.OverflowException: Arithmetic operation resulted in an overflow.
   at Maple2.Model.Common.Vector3S.op_Implicit(Vector3 vector) in C:\Users\Administrator\Documents\GitHub\Maple2\Maple2.Model\Common\Vector.cs:line 65
   at Maple2.Server.Game.Packets.NpcControlPacket.NpcBuffer(PoolByteWriter buffer, FieldNpc npc, Boolean isTalk) in C:\Users\Administrator\Documents\GitHub\Maple2\Maple2.Server.Game\Packets\NpcControlPacket.cs:line 48
   at Maple2.Server.Game.Packets.NpcControlPacket.Control(FieldNpc[] npcs) in C:\Users\Administrator\Documents\GitHub\Maple2\Maple2.Server.Game\Packets\NpcControlPacket.cs:line 21
   at Maple2.Server.Game.Manager.Field.FieldManager.BroadcastNpcControl(FieldNpc npc) in C:\Users\Administrator\Documents\GitHub\Maple2\Maple2.Server.Game\Manager\Field\FieldManager\FieldManager.cs:line 740
   at Maple2.Server.Game.Model.FieldNpc.Update(Int64 tickCount) in C:\Users\Administrator\Documents\GitHub\Maple2\Maple2.Server.Game\Model\Field\Actor\FieldNpc.cs:line 186
   at Maple2.Server.Game.Manager.Field.FieldManager.Update() in C:\Users\Administrator\Documents\GitHub\Maple2\Maple2.Server.Game\Manager\Field\FieldManager\FieldManager.cs:line 335
   at Maple2.Server.Game.Manager.Field.FieldManager.UpdateLoop() in C:\Users\Administrator\Documents\GitHub\Maple2\Maple2.Server.Game\Manager\Field\FieldManager\FieldManager.cs:line 313
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where converting 3D vector values to 16-bit integers could overflow; values are now clamped to the valid 16-bit range before conversion to prevent incorrect or out-of-range results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->