### PR TITLE
Fix decoration reward timestamp to prevent duplicate rewards

### DIFF
--- a/Maple2.Model/Game/User/Home.cs
+++ b/Maple2.Model/Game/User/Home.cs
@@ -158,7 +158,6 @@ public class Home : IByteSerializable {
             DecorationLevel++;
         }
 
-        DecorationRewardTimestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
         DecorationExp += exp;
     }
 

--- a/Maple2.Server.Game/Manager/HousingManager.cs
+++ b/Maple2.Server.Game/Manager/HousingManager.cs
@@ -407,6 +407,10 @@ public class HousingManager {
     public void InteriorCheckIn(Plot plot) {
         if (session.Field is null) return;
 
+        if (Home.DecorationRewardTimestamp != 0) {
+            return;
+        }
+
         Dictionary<HousingCategory, int> decorationCurrent = plot.Cubes.Values
             .Where(plotCube => plotCube.Metadata.Housing != null)
             .GroupBy(plotCube => plotCube.Metadata.Housing!.HousingCategory)
@@ -468,6 +472,7 @@ public class HousingManager {
         }
 
         Home.GainExp(decorationScore, tableMetadata.MasteryUgcHousingTable.Entries);
+        Home.DecorationRewardTimestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
         session.Send(CubePacket.DesignRankReward(Home));
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where decoration experience rewards could be claimed multiple times during a single interior check-in session by implementing proper reward claim tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->