### PR TITLE
refactor: replace Dictionary with ConcurrentDictionary for sessions

### DIFF
--- a/Maple2.Graphics.Interface/Maple2.Graphics.Interface.csproj
+++ b/Maple2.Graphics.Interface/Maple2.Graphics.Interface.csproj
@@ -1,9 +1,0 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-
-</Project>

--- a/Maple2.Server.Game/GameServer.cs
+++ b/Maple2.Server.Game/GameServer.cs
@@ -21,7 +21,7 @@ public class GameServer : Server<GameSession> {
     private readonly object mutex = new();
     private readonly FieldManager.Factory fieldFactory;
     private readonly HashSet<GameSession> connectingSessions;
-    private readonly Dictionary<long, GameSession> sessions;
+    private readonly ConcurrentDictionary<long, GameSession> sessions;
     private readonly ImmutableList<SystemBanner> bannerCache;
     private readonly ConcurrentDictionary<int, PremiumMarketItem> premiumMarketCache;
     private readonly GameStorage gameStorage;
@@ -36,7 +36,7 @@ public class GameServer : Server<GameSession> {
         _channel = (short) channel;
         this.fieldFactory = fieldFactory;
         connectingSessions = [];
-        sessions = new Dictionary<long, GameSession>();
+        sessions = new ConcurrentDictionary<long, GameSession>();
         this.gameStorage = gameStorage;
         this.debugGraphicsContext = debugGraphicsContext;
         this.itemMetadataStorage = itemMetadataStorage;
@@ -66,33 +66,34 @@ public class GameServer : Server<GameSession> {
     public override void OnConnected(GameSession session) {
         lock (mutex) {
             connectingSessions.Remove(session);
-            sessions[session.CharacterId] = session;
         }
+        sessions[session.CharacterId] = session;
     }
 
     public override void OnDisconnected(GameSession session) {
         lock (mutex) {
             connectingSessions.Remove(session);
-            sessions.Remove(session.CharacterId);
         }
+        // Only remove if this is still the registered session (reference equality).
+        // During same-channel migration, Disconnect() drains the send queue (up to 2s)
+        // before Dispose runs. In that window the client reconnects and the new session's
+        // OnConnected replaces this dict entry. Without this check, the old session's
+        // OnDisconnected would remove the new session, leaving the player unregistered
+        // and causing all subsequent heartbeats to fail.
+        // For cross-channel migration this is a non-issue since each server has its own dict.
+        sessions.TryRemove(KeyValuePair.Create(session.CharacterId, session));
     }
 
     public bool GetSession(long characterId, [NotNullWhen(true)] out GameSession? session) {
-        lock (mutex) {
-            return sessions.TryGetValue(characterId, out session);
-        }
+        return sessions.TryGetValue(characterId, out session);
     }
 
     public GameSession? GetSessionByAccountId(long accountId) {
-        lock (mutex) {
-            return sessions.Values.FirstOrDefault(session => session.AccountId == accountId);
-        }
+        return sessions.Values.FirstOrDefault(session => session.AccountId == accountId);
     }
 
     public List<GameSession> GetSessions() {
-        lock (mutex) {
-            return sessions.Values.ToList();
-        }
+        return sessions.Values.ToList();
     }
 
     protected override void AddSession(GameSession session) {
@@ -129,10 +130,8 @@ public class GameServer : Server<GameSession> {
             return;
         }
 
-        lock (mutex) {
-            foreach (GameSession session in sessions.Values) {
-                session.Send(GameEventPacket.Add(gameEvent));
-            }
+        foreach (GameSession session in sessions.Values) {
+            session.Send(GameEventPacket.Add(gameEvent));
         }
     }
 
@@ -141,10 +140,8 @@ public class GameServer : Server<GameSession> {
             return;
         }
 
-        lock (mutex) {
-            foreach (GameSession session in sessions.Values) {
-                session.Send(GameEventPacket.Remove(gameEvent.Id));
-            }
+        foreach (GameSession session in sessions.Values) {
+            session.Send(GameEventPacket.Remove(gameEvent.Id));
         }
     }
 
@@ -169,26 +166,20 @@ public class GameServer : Server<GameSession> {
     }
 
     public void DailyReset() {
-        lock (mutex) {
-            foreach (GameSession session in sessions.Values) {
-                session.DailyReset();
-            }
+        foreach (GameSession session in sessions.Values) {
+            session.DailyReset();
         }
     }
 
     public void WeeklyReset() {
-        lock (mutex) {
-            foreach (GameSession session in sessions.Values) {
-                session.WeeklyReset();
-            }
+        foreach (GameSession session in sessions.Values) {
+            session.WeeklyReset();
         }
     }
 
     public void MonthlyReset() {
-        lock (mutex) {
-            foreach (GameSession session in sessions.Values) {
-                session.MonthlyReset();
-            }
+        foreach (GameSession session in sessions.Values) {
+            session.MonthlyReset();
         }
     }
 
@@ -200,21 +191,19 @@ public class GameServer : Server<GameSession> {
                 session.Send(NoticePacket.Disconnect(new InterfaceText("GameServer Maintenance")));
                 session.Dispose();
             }
-            foreach (GameSession session in sessions.Values) {
-                session.Send(NoticePacket.Disconnect(new InterfaceText("GameServer Maintenance")));
-                session.Dispose();
-            }
-            fieldFactory.Dispose();
         }
+        foreach (GameSession session in sessions.Values) {
+            session.Send(NoticePacket.Disconnect(new InterfaceText("GameServer Maintenance")));
+            session.Dispose();
+        }
+        fieldFactory.Dispose();
 
         return base.StopAsync(cancellationToken);
     }
 
     public void Broadcast(ByteWriter packet) {
-        lock (mutex) {
-            foreach (GameSession session in sessions.Values) {
-                session.Send(packet);
-            }
+        foreach (GameSession session in sessions.Values) {
+            session.Send(packet);
         }
     }
 


### PR DESCRIPTION
Replace the Dictionary<long, GameSession> with
ConcurrentDictionary<long, GameSession> to provide thread-safe access without explicit locking. This eliminates the need for mutex locks around session dictionary operations.

Remove mutex locks from OnConnected, OnDisconnected, GetSession, GetSessionByAccountId, GetSessions, and event broadcasting methods since ConcurrentDictionary handles synchronization internally.

Update OnDisconnected to use TryRemove with KeyValuePair for atomic reference equality checks, ensuring the correct session is removed during reconnection scenarios (same-channel migration).

Remove unused Maple2.Graphics.Interface project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance & Stability**
  * Improved session management with enhanced concurrency handling to ensure more reliable and stable server operations during high-load scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->