### PR TITLE
Make WebController ranking methods private

### DIFF
--- a/Maple2.Server.Web/Controllers/WebController.cs
+++ b/Maple2.Server.Web/Controllers/WebController.cs
@@ -286,7 +286,7 @@ public class WebController : ControllerBase {
     #endregion
 
     #region Ranking
-    public ByteWriter Trophy(string userName) {
+    private ByteWriter Trophy(string userName) {
         string cacheKey = $"Trophy_{userName ?? "all"}";
 
         if (!cache.TryGetValue(cacheKey, out byte[]? cachedData)) {
@@ -312,7 +312,7 @@ public class WebController : ControllerBase {
         return result;
     }
 
-    public ByteWriter PersonalTrophy(long characterId) {
+    private ByteWriter PersonalTrophy(long characterId) {
         string cacheKey = $"PersonalTrophy_{characterId}";
 
         if (!cache.TryGetValue(cacheKey, out byte[]? cachedData)) {
@@ -328,7 +328,7 @@ public class WebController : ControllerBase {
         return result;
     }
 
-    public ByteWriter GuildTrophy(string userName) {
+    private ByteWriter GuildTrophy(string userName) {
         if (!string.IsNullOrEmpty(userName)) {
             string cacheKey = $"GuildTrophy_{userName}";
 
@@ -359,7 +359,7 @@ public class WebController : ControllerBase {
         return InGameRankPacket.GuildTrophy(GetCachedGuildTrophyRankings());
     }
 
-    public ByteWriter PersonalGuildTrophy(long characterId) {
+    private ByteWriter PersonalGuildTrophy(long characterId) {
         string cacheKey = $"PersonalGuildTrophy_{characterId}";
 
         if (!cache.TryGetValue(cacheKey, out byte[]? cachedData)) {
@@ -397,7 +397,7 @@ public class WebController : ControllerBase {
     }
     #endregion
 
-    public ByteWriter MenteeList(long accountId, long characterId) {
+    private ByteWriter MenteeList(long accountId, long characterId) {
         using GameStorage.Request db = gameStorage.Context();
         IList<long> list = db.GetMentorList(accountId, characterId);
 


### PR DESCRIPTION
Change the visibility of several ranking and mentor-related methods in WebController from public to private to restrict external access and improve encapsulation. Affected methods: Trophy, PersonalTrophy, GuildTrophy, PersonalGuildTrophy, and MenteeList.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code organization updates with no changes to user-facing functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->