### PR TITLE
fix: bonus attack coefficient broken for two-handed weapon classes

### DIFF
--- a/Maple2.Server.Core/Formulas/BonusAttack.cs
+++ b/Maple2.Server.Core/Formulas/BonusAttack.cs
@@ -9,11 +9,10 @@ public class BonusAttack {
         }
 
         double weaponBonusAttackCoefficient = RarityMultiplier(rightHandRarity);
-        if (leftHandRarity == 0) {
-            return weaponBonusAttackCoefficient;
+        if (leftHandRarity > 0) {
+            weaponBonusAttackCoefficient = 0.5 * (weaponBonusAttackCoefficient + RarityMultiplier(leftHandRarity));
         }
 
-        weaponBonusAttackCoefficient = 0.5 * (weaponBonusAttackCoefficient + RarityMultiplier(leftHandRarity));
         return 4.96 * weaponBonusAttackCoefficient * JobBonusMultiplier(jobCode);
     }
 

--- a/Maple2.Server.Game/Manager/StatsManager.cs
+++ b/Maple2.Server.Game/Manager/StatsManager.cs
@@ -73,8 +73,8 @@ public class StatsManager {
         return (1, 1);
 
         double BonusAttackCoefficient(FieldPlayer player) {
-            int leftHandRarity = player.Session.Item.Equips.Get(EquipSlot.RH)?.Rarity ?? 0;
-            int rightHandRarity = player.Session.Item.Equips.Get(EquipSlot.LH)?.Rarity ?? 0;
+            int rightHandRarity = player.Session.Item.Equips.Get(EquipSlot.RH)?.Rarity ?? 0;
+            int leftHandRarity = player.Session.Item.Equips.Get(EquipSlot.LH)?.Rarity ?? 0;
             return BonusAttack.Coefficient(rightHandRarity, leftHandRarity, player.Value.Character.Job.Code());
         }
     }


### PR DESCRIPTION
Two bugs in the bonus attack calculation caused 7/11 classes to deal drastically reduced damage:

1. StatsManager.BonusAttackCoefficient had EquipSlot reads swapped — rightHandRarity read from EquipSlot.LH and leftHandRarity read from EquipSlot.RH. Two-handed weapons store in EquipSlot.RH as their primary slot, so the swapped reads made rightHandRarity=0, causing BonusAttack.Coefficient to return 0.

2. BonusAttack.Coefficient early-returned the raw RarityMultiplier when leftHandRarity was 0, skipping the 4.96 * JobBonusMultiplier scaling. Two-handed classes got ~5.7x less bonus attack.

Affected classes: Berserker, Wizard, Archer, Heavy Gunner, Rune Blader, Striker, Soul Binder.