### PR TITLE
Upstream/joddy and dungeon clear fix

### DIFF
--- a/Maple2.Server.Game/Manager/Field/FieldManager/DungeonFieldManager.cs
+++ b/Maple2.Server.Game/Manager/Field/FieldManager/DungeonFieldManager.cs
@@ -64,6 +64,8 @@ public class DungeonFieldManager : FieldManager {
                 }
 
                 player.Session.Dungeon.CompleteDungeon(clearTimestamp);
+                player.Session.ConditionUpdate(ConditionType.dungeon_clear,
+                    codeLong: DungeonId);
 
             }
         }

--- a/Maple2.Server.Game/Trigger/TriggerContext.Player.cs
+++ b/Maple2.Server.Game/Trigger/TriggerContext.Player.cs
@@ -247,22 +247,24 @@ public partial class TriggerContext {
                     continue;
                 }
 
-                switch (questStates[0]) {
-                    case 1: // Started
-                        if (quest.State == QuestState.Started) {
-                            return !negate;
-                        }
-                        break;
-                    case 2: // Started and Can Complete
-                        if (quest.State == QuestState.Started && player.Session.Quest.CanComplete(quest)) {
-                            return !negate;
-                        }
-                        break;
-                    case 3: // Completed
-                        if (quest.State == QuestState.Completed) {
-                            return !negate;
-                        }
-                        break;
+                foreach (int questState in questStates) {
+                    switch (questState) {
+                        case 1: // Started (but NOT ready to complete)
+                            if (quest.State == QuestState.Started && !player.Session.Quest.CanComplete(quest)) {
+                                return !negate;
+                            }
+                            break;
+                        case 2: // Started and Can Complete
+                            if (quest.State == QuestState.Started && player.Session.Quest.CanComplete(quest)) {
+                                return !negate;
+                            }
+                            break;
+                        case 3: // Completed
+                            if (quest.State == QuestState.Completed) {
+                                return !negate;
+                            }
+                            break;
+                    }
                 }
             }
         }

--- a/Maple2.Server.Game/Util/ConditionUtil.cs
+++ b/Maple2.Server.Game/Util/ConditionUtil.cs
@@ -86,6 +86,7 @@ public static class ConditionUtil {
             case ConditionType.quest_accept:
             case ConditionType.quest_clear_by_chapter:
             case ConditionType.quest_clear:
+            case ConditionType.dungeon_clear:
             case ConditionType.buff:
             case ConditionType.enchant_result:
             case ConditionType.dialogue:


### PR DESCRIPTION
Two fixes for quest progression:

### 1. dungeon_clear condition fix (quest 50001601)
`ConditionType.dungeon_clear` (194) was never satisfied after dungeon boss kills. Added the condition to the quest_clear handler and emit `ConditionUpdate` on dungeon state change.

### 2. Joddy not appearing (Lv20 quest chain)
`QuestUserDetected` State1 incorrectly matched completable quests, causing DarkWindMovie to replay infinitely and Joddy (11003220) to never spawn. Players stuck between maps 52000067 ↔ 52000055.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dungeon completion tracking to properly update all players when a dungeon is cleared.
  * Fixed quest state detection to correctly evaluate all quest progression states.
  * Added proper support for dungeon clear condition evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->